### PR TITLE
AncorPointPanel: make radio-button background transparent

### DIFF
--- a/src/com/t_oster/uicomponents/AncorPointPanel.form
+++ b/src/com/t_oster/uicomponents/AncorPointPanel.form
@@ -70,6 +70,9 @@
   <SubComponents>
     <Component class="javax.swing.JRadioButton" name="rTopLeft">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>
@@ -78,6 +81,9 @@
     </Component>
     <Component class="javax.swing.JRadioButton" name="rTopCenter">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>
@@ -85,6 +91,9 @@
     </Component>
     <Component class="javax.swing.JRadioButton" name="rTopRight">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>
@@ -92,6 +101,9 @@
     </Component>
     <Component class="javax.swing.JRadioButton" name="rCenterLeft">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>
@@ -99,6 +111,9 @@
     </Component>
     <Component class="javax.swing.JRadioButton" name="rCenterCenter">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>
@@ -106,6 +121,9 @@
     </Component>
     <Component class="javax.swing.JRadioButton" name="rCenterRight">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>
@@ -113,6 +131,9 @@
     </Component>
     <Component class="javax.swing.JRadioButton" name="rBottomCenter">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>
@@ -120,6 +141,9 @@
     </Component>
     <Component class="javax.swing.JRadioButton" name="rBottomLeft">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>
@@ -127,6 +151,9 @@
     </Component>
     <Component class="javax.swing.JRadioButton" name="rBottomRight">
       <Properties>
+        <Property name="background" type="java.awt.Color" editor="org.netbeans.modules.form.RADConnectionPropertyEditor">
+          <Connection code="new Color(0,0,0,0)" type="code"/>
+        </Property>
         <Property name="buttonGroup" type="javax.swing.ButtonGroup" editor="org.netbeans.modules.form.RADComponent$ButtonGroupPropertyEditor">
           <ComponentRef name="radioButtonGroup"/>
         </Property>

--- a/src/com/t_oster/uicomponents/AncorPointPanel.java
+++ b/src/com/t_oster/uicomponents/AncorPointPanel.java
@@ -138,23 +138,32 @@ public class AncorPointPanel extends javax.swing.JPanel implements ActionListene
     rBottomLeft = new javax.swing.JRadioButton();
     rBottomRight = new javax.swing.JRadioButton();
 
+    rTopLeft.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rTopLeft);
     rTopLeft.setSelected(true);
 
+    rTopCenter.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rTopCenter);
 
+    rTopRight.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rTopRight);
 
+    rCenterLeft.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rCenterLeft);
 
+    rCenterCenter.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rCenterCenter);
 
+    rCenterRight.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rCenterRight);
 
+    rBottomCenter.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rBottomCenter);
 
+    rBottomLeft.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rBottomLeft);
 
+    rBottomRight.setBackground(new Color(0,0,0,0));
     radioButtonGroup.add(rBottomRight);
 
     javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);


### PR DESCRIPTION
at least in the classic java LAF, the ancorPointPanel looked strange (regression?) because each radioButton had a background that overdrew the rectangle behind that symbolizes the page
