### PR TITLE
Custom Mapping: add "everything else" option. Fixes #87

### DIFF
--- a/src/com/t_oster/visicut/VisicutModel.java
+++ b/src/com/t_oster/visicut/VisicutModel.java
@@ -23,6 +23,7 @@ import com.t_oster.liblasercut.LaserCutter;
 import com.t_oster.liblasercut.LaserJob;
 import com.t_oster.liblasercut.LaserProperty;
 import com.t_oster.liblasercut.ProgressListener;
+import com.t_oster.liblasercut.platform.Tuple;
 import com.t_oster.visicut.managers.LaserDeviceManager;
 import com.t_oster.visicut.managers.MappingManager;
 import com.t_oster.visicut.managers.MaterialManager;
@@ -654,13 +655,9 @@ public class VisicutModel
 
     for (PlfPart p : this.getPlfFile())
     {
-      if (p.getMapping() == null)
-      {
-        continue;
-      }
-      for (Mapping m : p.getMapping())
-      {
-        GraphicSet set = m.getFilterSet().getMatchingObjects(p.getGraphicObjects());
+      for (Tuple<Mapping, GraphicSet> t: p.getMappedGraphicObjects()) {
+        Mapping m = t.getA();
+        GraphicSet set = t.getB();
         LaserProfile pr = m.getProfile();
         List<LaserProperty> props = propmap.get(pr);
         pr.addToLaserJob(job, set, this.addFocusOffset(props, focusOffset));

--- a/src/com/t_oster/visicut/gui/beans/CustomMappingPanel.java
+++ b/src/com/t_oster/visicut/gui/beans/CustomMappingPanel.java
@@ -399,10 +399,20 @@ public class CustomMappingPanel extends EditableTablePanel implements EditableTa
       Component c = super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column);
       if (c instanceof JLabel && value instanceof FilterSet)
       {
-        String text = java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/CustomMappingPanel").getString("EVERYTHING");
-        if (!((FilterSet) value).isEmpty())
+        String text = null;
+        FilterSet fs = (FilterSet) value;
+        // TODO this code is duplicated in FilterSetCellEditor
+        if (fs.matchEverythingElse) {
+          text=java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("EVERYTHING ELSE");
+        } else if (fs.isEmpty()) {
+          text=java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("EVERYTHING");
+        } else {
+          text=java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("CUSTOM");
+        }
+        
+        if (!fs.isEmpty())
         {
-          MappingFilter f = ((FilterSet) value).getFirst();
+          MappingFilter f = fs.getFirst();
           text = FilterSetCellEditor.translateAttVal(f.getAttribute());
           String dots = ((FilterSet) value).size() > 1 ? "..." : "";
           if (f.getValue() instanceof Color)

--- a/src/com/t_oster/visicut/gui/beans/FilterSetCellEditor.java
+++ b/src/com/t_oster/visicut/gui/beans/FilterSetCellEditor.java
@@ -107,14 +107,31 @@ public class FilterSetCellEditor extends AbstractCellEditor implements TableCell
     }
   }
 
-  private void enforceMultiSelectState()
+  /**
+   * call this whenever a user changes the resultingFilterSet (or a option affecting it, like multiselect or everythingElse)
+   * 
+   * ActionHandlers of special options should first bring resultingfilterSet into a consistent state themselves and then call this function,
+   * because if two options conflict this function will default to the normal case without special options.
+   */
+  private void enforceConsistency()
   {
+    // TODO move this into FilterSet???
+    
     // if multiSelect is not enabled, only one selection may be chosen. This is enforced by removing everything but the last filter
-    if (!multiselect.isSelected()) {
-      while (FilterSetCellEditor.this.resultingFilterSet.size() > 1) {
-        FilterSetCellEditor.this.resultingFilterSet.removeFirst();
+    if (!resultingFilterSet.multiselectEnabled) {
+      while (resultingFilterSet.size() > 1) {
+        resultingFilterSet.removeFirst();
       }
     }
+    
+    // matchEverythingElse cannot be selected together with something else, e.g. "Color blue"
+    if (resultingFilterSet.size() > 0) {
+      resultingFilterSet.matchEverythingElse=false;
+    }
+    if (resultingFilterSet.matchEverythingElse) {
+      resultingFilterSet.multiselectEnabled=false;
+    }
+    //
   }
 
   class FilterMenuItem extends JCheckBoxMenuItem implements ActionListener
@@ -172,14 +189,14 @@ public class FilterSetCellEditor extends AbstractCellEditor implements TableCell
   FilterSet resultingFilterSet = new FilterSet();
   /// multiselect: if this is enabled, the user can select more than one item, see enforceMultiSelectState()
   JCheckBoxMenuItem multiselect = new JCheckBoxMenuItem(java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("MULTISELECT"));
-
+  JCheckBoxMenuItem everythingElse = new JCheckBoxMenuItem(java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("EVERYTHING ELSE"));
+    
   private void fillMenu(PlfPart p)
   {
     menu.removeAll();
     this.menuItems.clear();
     JMenuItem everything = new JMenuItem(java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("EVERYTHING"));
     everything.addActionListener(new ActionListener(){
-
       public void actionPerformed(ActionEvent ae)
       {
         FilterSetCellEditor.this.clearFilters();
@@ -190,6 +207,7 @@ public class FilterSetCellEditor extends AbstractCellEditor implements TableCell
     {
       GraphicSet gs = p.getGraphicObjects();
       menu.add(everything);
+      menu.add(everythingElse);
       for(final String s: gs.getAttributes())
       {
         JMenu m = new JMenu(translateAttVal(s));
@@ -210,7 +228,7 @@ public class FilterSetCellEditor extends AbstractCellEditor implements TableCell
   private void addFilter(MappingFilter f)
   {
     this.resultingFilterSet.add(f);
-    this.enforceMultiSelectState();
+    this.enforceConsistency();
     this.fireEditingStopped();
   }
 
@@ -239,7 +257,8 @@ public class FilterSetCellEditor extends AbstractCellEditor implements TableCell
     {
       i.refreshState();
     }
-    multiselect.setSelected(resultingFilterSet.multiselectEnabled);   
+    multiselect.setSelected(resultingFilterSet.multiselectEnabled);
+    everythingElse.setSelected(resultingFilterSet.matchEverythingElse);
   }
 
   public FilterSetCellEditor()
@@ -252,15 +271,28 @@ public class FilterSetCellEditor extends AbstractCellEditor implements TableCell
       public void actionPerformed(ActionEvent e)
       {
         resultingFilterSet.multiselectEnabled=multiselect.isSelected();
-        enforceMultiSelectState();
+        enforceConsistency();
         fireEditingStopped();
       }
     });
-  }
+    everythingElse.addActionListener(new ActionListener(){
+      public void actionPerformed(ActionEvent ae)
+      {
+        resultingFilterSet.matchEverythingElse=everythingElse.isSelected();
+        if (resultingFilterSet.matchEverythingElse) {
+          resultingFilterSet.clear();
+          resultingFilterSet.multiselectEnabled=false;
+        }
+        enforceConsistency();
+        fireEditingStopped();
+      }
+    });
+  };
 
 
   public Object getCellEditorValue()
   {
+    // TODO enforceConsistency() here???
     return resultingFilterSet;
   }
 
@@ -272,7 +304,16 @@ public class FilterSetCellEditor extends AbstractCellEditor implements TableCell
       // otherwise all items exept for the last one would be removed
       resultingFilterSet.multiselectEnabled = true;
     } 
-    bt.setText(((FilterSet) o).isEmpty() ? java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("EVERYTHING") : java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("CUSTOM"));
+    String text = null;
+    FilterSet f = (FilterSet) o;
+    if (f.matchEverythingElse) {
+      text=java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("EVERYTHING ELSE");
+    } else if (f.isEmpty()) {
+      text=java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("EVERYTHING");
+    } else {
+      text=java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor").getString("CUSTOM");
+    }
+    bt.setText(text);
     this.prepareMenu();
     return bt;
   }

--- a/src/com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor.properties
+++ b/src/com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor.properties
@@ -15,3 +15,4 @@ RECT=Rect
 LINE=Line
 SHAPE=Shape
 MULTISELECT=multiple selection
+EVERYTHING\ ELSE=everything else

--- a/src/com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor_de_DE.properties
+++ b/src/com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor_de_DE.properties
@@ -15,3 +15,4 @@ RECT=Rechteck
 LINE=Linie
 SHAPE=Shape
 MULTISELECT=Mehrfachauswahl
+EVERYTHING\ ELSE=alles andere

--- a/src/com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor_nl_NL.properties
+++ b/src/com/t_oster/visicut/gui/beans/resources/FilterSetCellEditor_nl_NL.properties
@@ -15,3 +15,4 @@ RECT=Rechthoek
 LINE=Lijn
 SHAPE=Vorm
 MULTISELECT=multiple selection
+EVERYTHING\ ELSE=everything else

--- a/src/com/t_oster/visicut/model/PlfPart.java
+++ b/src/com/t_oster/visicut/model/PlfPart.java
@@ -18,9 +18,12 @@
  **/
 package com.t_oster.visicut.model;
 
+import com.t_oster.liblasercut.platform.Tuple;
 import com.t_oster.visicut.model.graphicelements.GraphicSet;
+import com.t_oster.visicut.model.mapping.Mapping;
 import com.t_oster.visicut.model.mapping.MappingSet;
 import java.io.File;
+import java.util.LinkedList;
 
 /**
  *
@@ -59,6 +62,43 @@ public class PlfPart {
   public void setMapping(MappingSet mapping)
   {
     this.mapping = mapping;
+  }
+  
+  /**
+   * get a list of mappings and their matching graphic objects
+   */
+  public LinkedList<Tuple<Mapping, GraphicSet>> getMappedGraphicObjects() {
+    LinkedList<Tuple<Mapping, GraphicSet>> mappedSets = new LinkedList<Tuple<Mapping, GraphicSet>>();
+    if (this.getMapping()==null) {
+      // return empty list
+      return mappedSets;
+    }
+    GraphicSet matchedElements=new GraphicSet();
+    
+    // stage 1: match all normal elements
+    for (Mapping m : this.getMapping())
+    {
+      GraphicSet set = null;
+      if (!m.getFilterSet().matchEverythingElse) {
+        set=m.getFilterSet().getMatchingObjects(this.getGraphicObjects());
+        matchedElements.addAll(set);
+      }
+      mappedSets.add(new Tuple<Mapping, GraphicSet>(m,set));
+    }
+    
+    // stage 2: get all unmatched elements, they are for the "everything else" mappings
+    GraphicSet unmatchedElements = this.getGraphicObjects().clone();
+    unmatchedElements.removeAll(matchedElements);
+    // put them into the "everything else" mappings
+    for (Tuple<Mapping, GraphicSet> t: mappedSets)
+    {
+      Mapping m = t.getA();
+      if (m.getFilterSet().matchEverythingElse) {
+        t.setB(unmatchedElements);
+      }
+    }
+    
+    return mappedSets;
   }
   
   @Override

--- a/src/com/t_oster/visicut/model/mapping/FilterSet.java
+++ b/src/com/t_oster/visicut/model/mapping/FilterSet.java
@@ -35,8 +35,24 @@ public class FilterSet extends LinkedList<MappingFilter>
    */ 
   public boolean multiselectEnabled;
   
+  /**
+   * false: normal behaviour
+   * true: pseudo-FilerSet that matches everything unmatched by any other FilterSet of the same PlfPart
+   */
+  public boolean matchEverythingElse;
+  
+  /**
+   * filter a GraphicSet, return only matching elements
+   * this may not be called if matchEverythingElse==true, use PlfPart.getMappedGraphicObjects instead in this case!
+   * @param elements elements to be matched
+   * @return matching subset of the given elements
+   */
   public GraphicSet getMatchingObjects(GraphicSet elements)
   {
+    if (this.matchEverythingElse) {
+      throw new RuntimeException("getMatchingObjects must not be called when matchEverythingElse==true. Use PlfPart.getMappedGraphicObjects instead!");
+      // we cannot work around this because we would introduce the possibility of infinite recursion loops otherwise! PlfPart.getMappedGraphicsObjects calls this function.
+    }
     if (this.isEmpty())
     {
       return elements;
@@ -91,8 +107,13 @@ public class FilterSet extends LinkedList<MappingFilter>
           return false;
         }
       }
+      
       // equals() does NOT compare multiselectEnabled, because the behaviour is still equal.
       // TODO: are there possible side effects of comparing multiselectEnabled or not doing so?
+      
+      if (f.matchEverythingElse != matchEverythingElse) {
+        return false;
+      }
       return true;
     }
     return false;
@@ -107,6 +128,7 @@ public class FilterSet extends LinkedList<MappingFilter>
       result.add(f.clone());
     }
     result.multiselectEnabled=multiselectEnabled;
+    result.matchEverythingElse=matchEverythingElse;
     return result;
   }
 }


### PR DESCRIPTION
required some plumbing and code de-duplication in PlfPart and PreviewPanel.
Can still be improved (moving logic away from FilterSetCell editor into FilterSet itself)

Next step is a "ignore" dummy-profile so I can exclude things from "everything else".
