### PR TITLE
MappingFilter: fix Exception when attribute is not present

### DIFF
--- a/src/com/t_oster/visicut/model/mapping/MappingFilter.java
+++ b/src/com/t_oster/visicut/model/mapping/MappingFilter.java
@@ -100,6 +100,10 @@ public class MappingFilter
     if (value instanceof Number)
     {
       double number = ((Number) value).doubleValue();
+      if (e.getAttributeValues(attribute).isEmpty()) {
+        // object does not have the relevant attribute -> does not match (except if inverted)
+        return inverted;
+      }
       double other = ((Number) e.getAttributeValues(attribute).get(0)).doubleValue();
       result = attribute == null || (compare ? other <= number : other == number);
     }


### PR DESCRIPTION
when a GraphicsObject `e` does not have the filtered attribute, MappingFilter.matches() threw a IndexOutOfBoundsException in the expression `e.getAttributeValues(attribute).get(0)` 
