### PR TITLE
improve editRectangle handling. Fixes #135

### DIFF
--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -1643,7 +1643,6 @@ private void saveMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
 }//GEN-LAST:event_saveMenuItemActionPerformed
 
 private void newMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_newMenuItemActionPerformed
-  this.previewPanel.setEditRectangle(null);
   this.previewPanel.setZoom(100d);
   this.visicutModel1.newPlfFile();
 }//GEN-LAST:event_newMenuItemActionPerformed

--- a/src/com/t_oster/visicut/gui/PreviewPanelKeyboardMouseHandler.java
+++ b/src/com/t_oster/visicut/gui/PreviewPanelKeyboardMouseHandler.java
@@ -114,7 +114,7 @@ public class PreviewPanelKeyboardMouseHandler extends EditRectangleController im
       {
         PreviewPanelKeyboardMouseHandler.this.getSelectedSet().setTransform(
         PreviewPanelKeyboardMouseHandler.this.getSelectedSet().getBasicTransform());
-        PreviewPanelKeyboardMouseHandler.this.previewPanel.setEditRectangle(new EditRectangle(getSelectedPart().getBoundingBox()));
+        PreviewPanelKeyboardMouseHandler.this.previewPanel.updateEditRectangle();
         PreviewPanelKeyboardMouseHandler.this.previewPanel.repaint();
       }
     });
@@ -267,7 +267,7 @@ public class PreviewPanelKeyboardMouseHandler extends EditRectangleController im
     AffineTransform cur = getSelectedSet().getTransform();
     cur.preConcatenate(flipX);
     getSelectedSet().setTransform(cur);
-    previewPanel.setEditRectangle(null);
+    previewPanel.updateEditRectangle();
     previewPanel.clearCache(getSelectedPart());
     previewPanel.repaint();
   }
@@ -501,7 +501,7 @@ public class PreviewPanelKeyboardMouseHandler extends EditRectangleController im
           {//after rotate mode, select next available element
             if (elementsUnderCursor.size() == 1)
             {//only 1 element => toggle back to resize mode
-              this.previewPanel.setEditRectangle(new EditRectangle(VisicutModel.getInstance().getSelectedPart().getBoundingBox()));
+              this.previewPanel.updateEditRectangle();
             }
             else
             {//select next available element
@@ -861,7 +861,7 @@ public class PreviewPanelKeyboardMouseHandler extends EditRectangleController im
       tr.concatenate(getSelectedSet().getTransform());
     }
     getSelectedSet().setTransform(tr);
-    this.previewPanel.setEditRectangle(new EditRectangle(getSelectedPart().getBoundingBox()));
+    this.previewPanel.updateEditRectangle();
   }
 
   public void mouseMoved(MouseEvent evt)

--- a/src/com/t_oster/visicut/gui/beans/PreviewPanel.java
+++ b/src/com/t_oster/visicut/gui/beans/PreviewPanel.java
@@ -96,9 +96,7 @@ public class PreviewPanel extends ZoomablePanel implements PropertyChangeListene
     }
     else if (VisicutModel.PROP_SELECTEDPART.equals(pce.getPropertyName()))
     {
-      PlfPart p = VisicutModel.getInstance().getSelectedPart();
-      this.setEditRectangle(p != null ? new EditRectangle(p.getBoundingBox()) : null);
-      //this.repaint();//setEditRectangle does already repaint
+      updateEditRectangle();
     }
     else if (VisicutModel.PROP_PLF_PART_UPDATED.equals(pce.getPropertyName()))
     {
@@ -112,7 +110,7 @@ public class PreviewPanel extends ZoomablePanel implements PropertyChangeListene
         this.clearCache(p);
         if (p.equals(VisicutModel.getInstance().getSelectedPart()))
         {
-          this.setEditRectangle(new EditRectangle(p.getBoundingBox()));
+          updateEditRectangle();
         }
       }
     }
@@ -124,7 +122,7 @@ public class PreviewPanel extends ZoomablePanel implements PropertyChangeListene
     else if (VisicutModel.PROP_MATERIAL.equals(pce.getPropertyName())
       || VisicutModel.PROP_PLF_FILE_CHANGED.equals(pce.getPropertyName()))
     {
-      this.setEditRectangle(null);
+      updateEditRectangle();
       this.clearCache();
       repaint();
     }
@@ -404,12 +402,27 @@ public class PreviewPanel extends ZoomablePanel implements PropertyChangeListene
   }
 
   /**
+   * set editRectangle to the bounding-box of the selected part (or null if nothing is selected)
+   * side-effects: highlights the selection (thick border with resize controls) and calls repaint
+   */
+  public void updateEditRectangle() {
+    // TODO: instead of calling this from many different places, always update the edit-rectangle on repaint
+    // TODO: for this, the side effects of setEditRectangle need to be removed and, where necessary, explicit calls to them be added
+    PlfPart selectedPart = VisicutModel.getInstance().getSelectedPart();
+    if (selectedPart == null) {
+      setEditRectangle(null);
+    } else {
+      setEditRectangle(new EditRectangle(selectedPart.getBoundingBox()));
+    }
+  }
+  /**
    * Set the value of editRectangle
    * The EditRectangele is drawn if
    * The Values of the Rectangle are exspected to be
    * in LaserCutter Coordinate Space.
    *
    * @param editRectangle new value of editRectangle
+   * @see updateEditRectangle
    */
   public void setEditRectangle(EditRectangle editRectangle)
   {


### PR DESCRIPTION
Many places called setEditRectangle(getSelectedPart().getBoundingBox()); or setEditRectangle(null). This logic is now inside a new function updateEditRectangle().

I removed one unnecessary call in MainView was removed.
