### PR TITLE
added Fab Lab Berlin Visicut settings

### DIFF
--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -2506,6 +2506,7 @@ private void jmDownloadSettingsActionPerformed(java.awt.event.ActionEvent evt) {
   // choices.put("Country, City: Institution", "http://whatever.com/foo");
   choices.put("Germany, Aachen: FabLab RWTH Aachen", "https://github.com/renebohne/zing6030-visicut-settings/archive/master.zip");
   choices.put("Germany, Erlangen: FAU FabLab", "https://github.com/fau-fablab/visicut-settings/archive/master.zip");
+  choices.put("Germany, Berlin: Fab Lab Berlin", "https://github.com/FabLabBerlin/visicut-settings/archive/master.zip");
   choices.put("Netherlands, Amersfoort: FabLab", "https://github.com/Fablab-Amersfoort/visicut-settings/archive/master.zip");
   choices.put("United Kingdom, Manchester: Hackspace", "https://github.com/hacmanchester/visicut-settings/archive/master.zip");
   choices.put("United Kingdom, Leeds: Hackspace", "https://github.com/pbrook/visicut-settings/archive/master.zip");


### PR DESCRIPTION
as stated in https://github.com/t-oster/VisiCut/wiki/How-to-add-default-settings-for-your-lab 

this pull request will introduce the Fab Lab Berlin laser settings into visicut