### PR TITLE
Hello from Fab Lab Nuremberg

### DIFF
--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -2920,6 +2920,7 @@ private void jmDownloadSettingsActionPerformed(java.awt.event.ActionEvent evt) {
   // choices.put("Country, City: Institution", "http://whatever.com/foo");
   choices.put("Germany, Aachen: FabLab RWTH Aachen", "https://github.com/renebohne/zing6030-visicut-settings/archive/master.zip");
   choices.put("Germany, Erlangen: FAU FabLab", "https://github.com/fau-fablab/visicut-settings/archive/master.zip");
+  choices.put("Germany, Nuremberg: Fab lab Region Nürnberg e.V.", "https://github.com/fablabnbg/visicut-settings/archive/master.zip");
   choices.put("Germany, Berlin: Fab Lab Berlin", "https://github.com/FabLabBerlin/visicut-settings/archive/master.zip");
   choices.put("Germany, Bremen: FabLab Bremen e.V.", "http://www.fablab-bremen.org/FabLab_Bremen.vcsettings");
   choices.put("Germany, Paderborn: FabLab Paderborn e.V.", "https://github.com/fablab-paderborn/visicut-settings/archive/master.zip");


### PR DESCRIPTION
We use VisiCut currently only with our lasercutter. This PR references our settings.
Next thing is to add a visicut drivers for a Goldcut ABH 721 cutter/plotter  -- that appears to be simple HPGL... 
I've also started tinkering with our iModela, and with a Silhouette Cameo. More to be added to the settings then.