### PR TITLE
Added IllustratorScript for Windows (Fixes #286)

### DIFF
--- a/distribute/distribute.sh
+++ b/distribute/distribute.sh
@@ -37,6 +37,7 @@ cp ../tools/inkscape_extension/*.py visicut/inkscape_extension/
 cp ../tools/inkscape_extension/*.inx visicut/inkscape_extension/
 mkdir -p visicut/illustrator_script
 cp ../tools/illustrator_script/*.scpt visicut/illustrator_script/
+cp ../tools/illustrator_script/*.vbs visicut/illustrator_script/
 echo "Compressing content..."
 [ -f VisiCut-$VERSION.zip ] && rm VisiCut-$VERSION.zip
 zip -r VisiCut-$VERSION.zip visicut/  > /dev/null || exit 1

--- a/src/com/t_oster/visicut/misc/Helper.java
+++ b/src/com/t_oster/visicut/misc/Helper.java
@@ -310,7 +310,8 @@ public class Helper
       new File("/Applications/Adobe Illustrator CS6/Presets"),      
       new File("/Applications/Adobe Illustrator CS4/Presets.localized"),
       new File("/Applications/Adobe Illustrator CS5/Presets.localized"),
-      new File("/Applications/Adobe Illustrator CS6/Presets.localized")
+      new File("/Applications/Adobe Illustrator CS6/Presets.localized"),
+      new File("C:/Program Files/Adobe/Adobe Illustrator CC 2015/Presets.localized"),
     })
     {
       if (dir.exists() && dir.isDirectory())
@@ -658,12 +659,12 @@ public class Helper
 
   private static File getIllustratorScript()
   {
-    return new File(new File(getVisiCutFolder(), "illustrator_script"), "OpenWithVisiCut.scpt");
+    return new File(new File(getVisiCutFolder(), "illustrator_script"), isWindows() ? "OpenWithVisiCut.vbs" : "OpenWithVisiCut.scpt");
   }
 
   public static boolean isIllustratorScriptInstallable()
   {
-    return isMacOS() && getIllustratorScript().exists();
+    return (isMacOS() || isWindows()) && getIllustratorScript().exists();
   }
 
   public static String allowedChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.-";

--- a/tools/illustrator_script/OpenWithVisiCut.vbs
+++ b/tools/illustrator_script/OpenWithVisiCut.vbs
@@ -1,0 +1,24 @@
+'Exports the current document as SVG to dest
+'dest contains the full path and file name to save to
+
+destFile = "C:\temp\VCtemp.svg"
+exportFileAsSVG (destFile)
+
+Sub exportFileAsSVG (dest)
+Set appRef = CreateObject("Illustrator.Application")
+Set svgExportOptions = CreateObject("Illustrator.ExportOptionsSVG")
+
+If appRef.Documents.Count > 0 Then
+     svgExportOptions.EmbedRasterImages = True
+     svgExportOptions.FontSubsetting = 7 'aiAllGlyphs
+     Set docRef = appRef.ActiveDocument
+     Call docRef.Export (dest, 3, svgExportOptions) ' 3 = aiSVG
+End If
+End Sub
+
+'open document in VisiCut
+
+strFileName = "C:\temp\VCtemp.svg"
+Set oShell = CreateObject("WScript.Shell")
+
+oShell.Run "visicut.exe "  & strFileName


### PR DESCRIPTION
This will add a windows-compatible version of the Adobe Illustrator Extension to the menu.

TODO:
 * [ ] Test if the installation works
 * [ ] Add (x64 and x86) Paths for all important Versions of Illustrator or find a method to determine the path of an installed version
 * [ ] Test the script on all important versions of Illustrator