### PR TITLE
Suppress duplicate camera warning messages

### DIFF
--- a/src/com/frochr123/periodictasks/RefreshCameraThread.java
+++ b/src/com/frochr123/periodictasks/RefreshCameraThread.java
@@ -29,8 +29,8 @@ public class RefreshCameraThread extends Thread
 {
   // Constant values
   public static final int DEFAULT_CAMERA_TIME = 50;
-  public static final int DEFAULT_CAMERA_LONG_WAIT_TIME = 15000;
-  
+  public static final int DEFAULT_CAMERA_LONG_WAIT_TIME = 6000;
+
   // Constructor
   public RefreshCameraThread()
   {
@@ -56,7 +56,7 @@ public class RefreshCameraThread extends Thread
   {
     return MainView.getInstance().isCameraActive() && MainView.getInstance().isPreviewPanelShowBackgroundImage();
   }
- 
+
   // Run method
   @Override
   public void run()
@@ -65,16 +65,23 @@ public class RefreshCameraThread extends Thread
     {
       try
       {
-        // Check if last run caused exception
-        if (!MainView.getInstance().getCameraCapturingError().isEmpty())
+        // Check if last image capture has finished
+        String error = MainView.getInstance().getCameraCapturingError();
+        if (error != null)
         {
-          // Sleep extra long time, avoid spamming of warnings
-          MainView.getInstance().getDialog().showWarningMessage(MainView.getInstance().getCameraCapturingError());
           MainView.getInstance().resetCameraCapturingError();
-          Thread.currentThread().sleep(DEFAULT_CAMERA_LONG_WAIT_TIME);
-          continue;
+          if (error.isEmpty()) {
+            // successfully captured
+            MainView.getInstance().getDialog().removeMessageWithId("camera error");
+          } else {
+            // error has occured
+            MainView.getInstance().getDialog().showWarningMessageOnce(error, "camera error", 2 * DEFAULT_CAMERA_LONG_WAIT_TIME);
+            // sleep some extra time, so that VisiCam isn't overloaded
+            Thread.sleep(DEFAULT_CAMERA_LONG_WAIT_TIME);
+            continue;
+          }
         }
-
+        
         // Check if thread should be working
         if (!isActive())
         {
@@ -82,7 +89,7 @@ public class RefreshCameraThread extends Thread
           Thread.currentThread().sleep(getUpdateTimerMs() * 5);
           continue;
         }
-        
+
         // Call capture new image if everyhing is fine
         if (!MainView.getInstance().getVisiCam().isEmpty())
         {

--- a/src/com/t_oster/visicut/misc/DialogHelper.java
+++ b/src/com/t_oster/visicut/misc/DialogHelper.java
@@ -182,6 +182,12 @@ public class DialogHelper
   {
     JOptionPane.showMessageDialog(parent, text, title, JOptionPane.WARNING_MESSAGE);
   }
+  
+  public void showWarningMessageOnce(String text, String messageId, int timeoutMilliseconds) {
+    // timeout or 'show once' is not implemented in this simple implementation, but this method
+    // is overridden in MainView
+    showWarningMessage(text);
+  }
 
   public void showSuccessMessage(String text)
   {
@@ -207,6 +213,10 @@ public class DialogHelper
   public void showErrorMessage(String text)
   {
     JOptionPane.showMessageDialog(parent, text, title + " Error", JOptionPane.ERROR_MESSAGE);
+  }
+  
+  public void removeMessageWithId(String messageId) {
+    // do nothing, needs to be implemented by subclass
   }
 
   private Double askUnit(UnitTextfield tf, String text, double val)


### PR DESCRIPTION
The camera code now shows at most one warning message, automatically replacing older messages. As soon as the image has been fetched successfully, old warnings are automatically closed.

This fixes #294 and the main problem described in #291.

Because I neither use nor really understand it, I have not tested the QR-reading code, which needed to be changed slightly. I roughly tested the image fetching code against a random webserver and a sometimes broken network connection. 
