### PR TITLE
Bring window to front when loading file from plugin

### DIFF
--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -1591,6 +1591,10 @@ public class MainView extends javax.swing.JFrame
   
   private void loadFileReal(File file, boolean discardCurrent)
   {
+    // bring window to front - needed when VisiCut was called from a plugin
+    this.toFront();
+    this.requestFocus();
+    
     // remove old error messages, they are no longer relevant (or for multiple files it is too confusing which one refers to which file)
     warningPanel.removeAllWarnings();
 


### PR DESCRIPTION
VisiCut should get the user's attention when it is called from the inkscape plugin. It now tries to get into foreground. Some window managers don't allow that, but then at least the VisiCut entry in the taskbar starts blinking.