### PR TITLE
Editable Job Name

### DIFF
--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -1658,7 +1658,6 @@ public class MainView extends javax.swing.JFrame
     this.calculateTimeButton.setVisible(estimateSupported);
     this.timeLabel.setVisible(estimateSupported);
     this.jLabel10.setVisible(estimateSupported);
-    this.jLabelJobName.setVisible(estimateSupported);
     //check for focus-property in at least one profile type
     boolean focusSupported = false;
     if (this.visicutModel1.getSelectedLaserDevice() != null)

--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -648,6 +648,8 @@ public class MainView extends javax.swing.JFrame
         jLabel9 = new javax.swing.JLabel();
         laserCutterComboBox = new com.t_oster.uicomponents.ImageComboBox();
         jLabel10 = new javax.swing.JLabel();
+        jLabelJobName = new javax.swing.JLabel();
+        jTextFieldJobName = new javax.swing.JTextField();
         calculateTimeButton = new javax.swing.JButton();
         timeLabel = new javax.swing.JLabel();
         mappingTabbedPane = new javax.swing.JTabbedPane();
@@ -797,6 +799,8 @@ public class MainView extends javax.swing.JFrame
 
         jLabel10.setText(resourceMap.getString("jLabel10.text")); // NOI18N
         jLabel10.setName("jLabel10"); // NOI18N
+        jLabelJobName.setText(resourceMap.getString("jLabelJobName.text")); // NOI18N
+        jLabelJobName.setName("jLabelJobName"); // NOI18N
 
         calculateTimeButton.setText(resourceMap.getString("calculateTimeButton.text")); // NOI18N
         calculateTimeButton.setEnabled(false);
@@ -902,7 +906,13 @@ public class MainView extends javax.swing.JFrame
                 .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(jPanel2Layout.createSequentialGroup()
                         .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(executeJobButton, javax.swing.GroupLayout.Alignment.TRAILING)
+                            .addGroup(jPanel2Layout.createSequentialGroup()
+                                .addComponent(jLabelJobName)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(jTextFieldJobName, javax.swing.GroupLayout.DEFAULT_SIZE, 10, Short.MAX_VALUE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 199, Short.MAX_VALUE)
+				.addComponent(executeJobButton))
+
                             .addGroup(jPanel2Layout.createSequentialGroup()
                                 .addComponent(jLabel10)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -981,8 +991,13 @@ public class MainView extends javax.swing.JFrame
                     .addComponent(timeLabel, javax.swing.GroupLayout.PREFERRED_SIZE, 23, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(jLabel10)
                     .addComponent(calculateTimeButton))
+
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addComponent(executeJobButton)
+
+                .addGroup(jPanel2Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                  .addComponent(jLabelJobName)
+                  .addComponent(jTextFieldJobName)
+                  .addComponent(executeJobButton))
                 .addContainerGap())
         );
 
@@ -1643,6 +1658,7 @@ public class MainView extends javax.swing.JFrame
     this.calculateTimeButton.setVisible(estimateSupported);
     this.timeLabel.setVisible(estimateSupported);
     this.jLabel10.setVisible(estimateSupported);
+    this.jLabelJobName.setVisible(estimateSupported);
     //check for focus-property in at least one profile type
     boolean focusSupported = false;
     if (this.visicutModel1.getSelectedLaserDevice() != null)
@@ -1697,6 +1713,7 @@ public class MainView extends javax.swing.JFrame
         execute = false;
       }
     }
+    this.jTextFieldJobName.setText( "" );
     this.calculateTimeButton.setEnabled(execute);
     this.executeJobButton.setEnabled(execute);
     this.executeJobMenuItem.setEnabled(execute);
@@ -1825,12 +1842,21 @@ private void aboutMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN
           MainView.this.progressBar.setStringPainted(true);
           MainView.this.executeJobButton.setEnabled(false);
           MainView.this.executeJobMenuItem.setEnabled(false);
+          String jobname = "(unnamed job)";
           try
           {
             MainView.this.warningPanel.removeAllWarnings();
             jobnumber++;
+            String nameprefix = MainView.this.jTextFieldJobName.getText();
+	    //
+	    // Most simplistic implementation of user editable job names:
+	    //  - we just add a prefix, if any. (This is okay for Zing lasers that only display 16 chars.)
+	    // Todo: Better compute the next proposed job name in e.g. refreshExecuteButtons() ahead of time 
+	    // and show it in jTextFieldJobName near the Execute button. When we come here, just retrieve the 
+	    // (possibly edited) name from there.
+	    //
             String prefix = MainView.this.visicutModel1.getSelectedLaserDevice().getJobPrefix();
-            String jobname = prefix+jobnumber;
+            jobname = nameprefix+prefix+jobnumber;
             if (PreferencesManager.getInstance().getPreferences().isUseFilenamesForJobs())
             {
               //use filename of the PLF file or any part with a filename as job name
@@ -1850,7 +1876,7 @@ private void aboutMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN
               }
               if (f != null)
               {
-                jobname = f.getName();
+                jobname = nameprefix + f.getName();
               }
             }
             List<String> warnings = new LinkedList<String>();
@@ -3106,6 +3132,8 @@ private void projectorActiveMenuItemActionPerformed(java.awt.event.ActionEvent e
     private javax.swing.JCheckBox jCheckBox1;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel10;
+    private javax.swing.JLabel jLabelJobName;
+    private javax.swing.JTextField jTextFieldJobName;
     private javax.swing.JLabel jLabel2;
     private javax.swing.JLabel jLabel5;
     private javax.swing.JLabel jLabel9;
@@ -3345,6 +3373,7 @@ private void projectorActiveMenuItemActionPerformed(java.awt.event.ActionEvent e
       executeJobButton.setEnabled(!disable);
       executeJobMenuItem.setEnabled(!disable);
       calculateTimeButton.setEnabled(!disable);
+      jTextFieldJobName.setText( "" );
 
       // Message is automatically removed and closed, therefore no close button
       Message m = new Message("Info", bundle.getString("QR_CODE_DETECTION_GUI_DISABLE_TEXT"), Message.Type.INFO, new com.t_oster.uicomponents.warnings.Action[]

--- a/src/com/t_oster/visicut/gui/resources/MainView.properties
+++ b/src/com/t_oster/visicut/gui/resources/MainView.properties
@@ -30,6 +30,7 @@ zoomOut.Action.accelerator=ctrl pressed MINUS
 zoomOut.Action.shortDescription=
 zoomOut.Action.text=Zoom out
 jLabel10.text=Estimated Time:
+jLabelJobName.text=Job Name Prefix:
 timeLabel.text=unknown
 calculateTimeButton.text=Calculate
 jButton1.text=


### PR DESCRIPTION
The Zing lasercutter only shows the first 16 characters of a job name.
The 'ink_ext' prefix or filename are sometimes insufficient to clearly
distinguish jobs when navigating the job history on the lasercutter.
Especially, when the same object is sent multiple times with different
visicut-settings (engrave, cut, ...) it would be great, to give descriptive names, what the change was.

This commit provides a way for the user to add a short memonic text information
to the job name.

This helps for later retrieval from the job history and also
when multiple users send jobs with possibly similar jobs names.