### PR TITLE
Properties Panel only shows one filter for each property.

### DIFF
--- a/src/com/t_oster/visicut/gui/propertypanel/PropertiesPanel.java
+++ b/src/com/t_oster/visicut/gui/propertypanel/PropertiesPanel.java
@@ -146,6 +146,10 @@ public class PropertiesPanel extends javax.swing.JPanel implements PropertyChang
   private void updatePanels()
   {
     this.removeAll();
+    for (Entry<LaserProfile, PropertyPanel> e : panels.entrySet())
+    {
+      e.getValue().resetPanel();
+    }
     LaserDevice ld = VisicutModel.getInstance().getSelectedLaserDevice();
     MaterialProfile mp = VisicutModel.getInstance().getMaterial();
     float thickness = VisicutModel.getInstance().getMaterialThickness();

--- a/src/com/t_oster/visicut/gui/propertypanel/PropertyPanel.java
+++ b/src/com/t_oster/visicut/gui/propertypanel/PropertyPanel.java
@@ -63,16 +63,25 @@ public class PropertyPanel extends javax.swing.JPanel implements EditableTablePr
     });
   }
   
+  private String allfilters = "";
   private String text = "title";
   private String title = java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/resources/PropertyPanel").getString("PROPERTY_TITLE");
   private String unused = java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/resources/PropertyPanel").getString("UNUSED");
-  
+
+  public void resetPanel()
+  {
+    // Panels have state and get re-used by updatePanels(). reloadPanels() avoids re-using.
+    allfilters = "";
+  }
+
   public void setMapping(Mapping m, boolean isUnused)
   {
     
     String profile = m.getProfile() != null ? m.getProfile().getName() : java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/mapping/resources/CustomMappingPanel").getString("IGNORE");
     String filters = m.getFilterSet() != null ? m.getFilterSet().toString() : java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/mapping/resources/CustomMappingPanel").getString("EVERYTHING_ELSE");
-    text = title.replace("$profile", profile).replace("$mapping", filters);
+    allfilters += (allfilters == "" ? "" : ", ") + filters;
+    text = title.replace("$profile", profile).replace("$mapping", allfilters);
+
     //change colors to their html representation
     text = text.replaceAll("#([0-9a-fA-F]+)", "<span bgcolor='$1' color='$1'>bla</span>");
     if (isUnused)


### PR DESCRIPTION
It shows e.g. one stroke-color for cut, even if multiple stroke colors map to cut.

With this fix we list all selected filters for each property in the Laser Settings panel.
Less confusing to the user who selected multiple colors in 'mapping', but only sees the last one, when switching to 'Laser Settings'.

This fixes https://github.com/fablabnbg/VisiCut/issues/1