### PR TITLE
Remember the last used folder when exporting

### DIFF
--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -1799,7 +1799,8 @@ private void openMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
       this.previewPanel.repaint();
     }
   }
-
+  
+  private JFileChooser fileChooser = new JFileChooser();
 	private void generateGcodeMenuItemActionPerformed( java.awt.event.ActionEvent evg ) {
 		String jobname = getJobName();
 		List<String> warnings = new LinkedList<String>();
@@ -1822,10 +1823,9 @@ private void openMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
 			}
 		};
 		try {
-			JFileChooser fileChooser = new JFileChooser();
-			int userreturn = fileChooser.showSaveDialog(this);
+			int userreturn = this.fileChooser.showSaveDialog(this);
 			if( userreturn == JFileChooser.APPROVE_OPTION) {
-				File selectedFile = fileChooser.getSelectedFile();
+				File selectedFile = this.fileChooser.getSelectedFile();
 				System.out.println( "selected " + selectedFile.getAbsolutePath() );
 
 				MainView.this.visicutModel1


### PR DESCRIPTION
Each time you run Export Laser Code, the JFileChooser starts at your home directory, rather than where you last saved a file.

This change makes the JFileChooser remember its last directory and file name, making it easy to export a job several times.