### PR TITLE
Suppress duplicate "Everything Else" mapping entries

### DIFF
--- a/src/com/t_oster/visicut/gui/mapping/PropertyMappingPanelTable.java
+++ b/src/com/t_oster/visicut/gui/mapping/PropertyMappingPanelTable.java
@@ -301,11 +301,21 @@ public class PropertyMappingPanelTable extends EditableTablePanel implements Edi
       }
     }
     //add everything else
-    MappingTableEntry e = new MappingTableEntry();
-    e.enabled = false;
-    e.filterSet = null;
-    e.profile = defaultProfile;
-    entries.add(e);
+    boolean suppressDuplicateEverythingElse=false;
+    for (MappingTableEntry existingEntry: entries) {
+      if (existingEntry.filterSet == null) {
+        suppressDuplicateEverythingElse=true;
+        break;
+      }
+    }
+    if (!suppressDuplicateEverythingElse)
+    {
+      MappingTableEntry e = new MappingTableEntry();
+      e.enabled = false;
+      e.filterSet = null;
+      e.profile = defaultProfile;
+      entries.add(e);
+    }
     suppressMappingUpdate = true;
     model.fireTableDataChanged();
     suppressMappingUpdate = false;


### PR DESCRIPTION
These appeared if you saved a plf with an enabled Everything Else mapping and reloaded it. Now the default entry is only added if it's not already found in the mapping list.