### PR TITLE
Explicitly close gcode export file

### DIFF
--- a/src/com/t_oster/visicut/VisicutModel.java
+++ b/src/com/t_oster/visicut/VisicutModel.java
@@ -779,6 +779,7 @@ public class VisicutModel
 	  {
 		  lasercutter.saveJob(fileOutputStream, job);
 	  }
+    fileOutputStream.close();
   }
 
   public int estimateTime(Map<LaserProfile, List<LaserProperty>> propmap) throws FileNotFoundException, IOException


### PR DESCRIPTION
Fixes issue #355. Java doesn't automatically destroy objects when they go out of scope, only when they are GC'ed. So we need to explicitly close the exported file.

Another solution would be to use try-with-resources, but that's java 7+.