### PR TITLE
Fix inkscape extension issues on XP

### DIFF
--- a/src/com/t_oster/visicut/misc/Helper.java
+++ b/src/com/t_oster/visicut/misc/Helper.java
@@ -253,20 +253,34 @@ public class Helper
     {
       throw new FileNotFoundException("Not a directory: "+src);
     }
-    File trg = null;
-    if (isWindowsXP())
+    
+    String profile_path = System.getenv("INKSCAPE_PORTABLE_PROFILE_DIR");
+
+    if (profile_path == null)
     {
-        trg = new File(new File(FileUtils.getUserDirectory(), ".inkscape"), "extensions");
+      profile_path = System.getenv("INKSCAPE_PROFILE_DIR");
     }
-    else if (isWindows())
+
+    File trg;
+
+    if (profile_path != null)
     {
-        trg = new File(new File(new File(System.getenv("AppData")), "inkscape"), "extensions");
+      trg = new File(profile_path);
     }
     else
     {
-      trg = new File(new File(new File(FileUtils.getUserDirectory(), ".config"), "inkscape"), "extensions");
+      if (isWindows())
+      {
+        trg = new File(System.getenv("AppData"));
+      }
+      else
+      {
+        trg = new File(FileUtils.getUserDirectory(), ".config");
+      }
     }
-
+    
+    trg = new File(new File(trg, "inkscape"), "extensions");      
+    
     if (!trg.exists() && !trg.mkdirs())
     {
       throw new FileNotFoundException("Can't create directory: "+trg);

--- a/tools/inkscape_extension/visicut_export.py
+++ b/tools/inkscape_extension/visicut_export.py
@@ -67,16 +67,19 @@ if (sys.platform == "win32"):
             k32 = ctypes.windll.kernel32
             wow64 = ctypes.c_long( 0 )
             # disable system32 redirection
-            k32.Wow64DisableWow64FsRedirection( ctypes.byref(wow64) )
-            # do what we want
             try:
-                query_output=querySession()
-            except WindowsError:
-                #in some cases query doesn't exist on windows 7 if terminal services isn't installed
+                k32.Wow64DisableWow64FsRedirection( ctypes.byref(wow64) )
+                # do what we want
+                try:
+                    query_output=querySession()
+                except WindowsError:
+                    #in some cases query doesn't exist on windows 7 if terminal services isn't installed
+                    pass
+                finally:
+                    # re-enable system32 redirection
+                    k32.Wow64EnableWow64FsRedirection( wow64 )
+            except AttributeError:
                 pass
-            finally:
-                # re-enable system32 redirection
-                k32.Wow64EnableWow64FsRedirection( wow64 )
         
         if query_output is not None:
             id=None


### PR DESCRIPTION
Fixes most of #361 - properly identifies the inkscape preferences directory using the same logic as inkscape itself, and handles the lack of the 64/32 redirection API on 32-bit XP.