### PR TITLE
Do not use width="100%" height="100%" for scaling when seen in document root

### DIFF
--- a/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGImporter.java
+++ b/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGImporter.java
@@ -274,10 +274,18 @@ public class SVGImporter extends AbstractImporter
       if (root.getPres(sty.setName("width")))
       {
         width = numberWithUnitsToMm(sty.getNumberWithUnits(), svgResolution);
+        if (sty.getNumberWithUnits().getUnits() == NumberWithUnits.UT_PERCENT)
+	  {
+	    width = 0;	// cannot use percent here!
+	  }
       }
       if (root.getPres(sty.setName("height")))
       {
         height = numberWithUnitsToMm(sty.getNumberWithUnits(), svgResolution);
+        if (sty.getNumberWithUnits().getUnits() == NumberWithUnits.UT_PERCENT)
+	  {
+	    height = 0;	// cannot use percent here!
+	  }
       }
       if (width != 0 && height != 0 && root.getPres(sty.setName("viewBox")))
       {


### PR DESCRIPTION
Fixes https://github.com/fablabnbg/VisiCut/issues/7

I am unsure, if there are other cases, where UT_PERCENT is misinterpreted. Please double check!