### PR TITLE
Fix https://github.com/t-oster/VisiCut/issues/347

### DIFF
--- a/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGImporter.java
+++ b/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGImporter.java
@@ -221,7 +221,7 @@ public class SVGImporter extends AbstractImporter
 		try { vers_min = Integer.parseInt(matcher.group(2)); }
 		catch (NumberFormatException e) { vers_min = -1; }
 
-		if ((vers_maj >= 0) && (vers_min >= 92))
+		if (((vers_maj == 0) && (vers_min >= 92)) || (vers_maj > 0))
 		  {
 		    InkscapeVersion092Seen = true;
 		  }

--- a/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGImporter.java
+++ b/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGImporter.java
@@ -274,10 +274,18 @@ public class SVGImporter extends AbstractImporter
       if (root.getPres(sty.setName("width")))
       {
         width = numberWithUnitsToMm(sty.getNumberWithUnits(), svgResolution);
+        if (sty.getNumberWithUnits().getUnits() == NumberWithUnits.UT_PERCENT)
+	  {
+	    width = 0;	// cannot use percent here!
+	  }
       }
       if (root.getPres(sty.setName("height")))
       {
         height = numberWithUnitsToMm(sty.getNumberWithUnits(), svgResolution);
+        if (sty.getNumberWithUnits().getUnits() == NumberWithUnits.UT_PERCENT)
+	  {
+	    height = 0;	// cannot use percent here!
+	  }
       }
       if (width != 0 && height != 0 && root.getPres(sty.setName("viewBox")))
       {


### PR DESCRIPTION
Inkscape 0.92 generates SVG in 96 DPI, all earlier version do 90 DPI.