### PR TITLE
Improve error messages for exceptions

### DIFF
--- a/src/com/t_oster/visicut/gui/CamCalibrationDialog.java
+++ b/src/com/t_oster/visicut/gui/CamCalibrationDialog.java
@@ -36,6 +36,7 @@ import com.t_oster.visicut.misc.Homography;
 import com.t_oster.visicut.model.LaserDevice;
 import com.t_oster.visicut.model.VectorProfile;
 import com.t_oster.uicomponents.PlatformIcon;
+import com.t_oster.visicut.misc.DialogHelper;
 import java.awt.event.MouseWheelEvent;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.NoninvertibleTransformException;
@@ -96,6 +97,7 @@ public class CamCalibrationDialog extends javax.swing.JDialog
     new Point2D.Double(0.7d, 0.5d), // mid right
   };
 
+  final protected DialogHelper dialog = new DialogHelper(this, this.getTitle());
 
   /**
    * Get the value of backgroundImage
@@ -153,7 +155,7 @@ public class CamCalibrationDialog extends javax.swing.JDialog
         }
         catch (Exception ex)
         {
-          JOptionPane.showMessageDialog(CamCalibrationDialog.this, java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/resources/CamCalibrationDialog").getString("ERROR LOADING IMAGE:") + ex.getLocalizedMessage(), java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/resources/CamCalibrationDialog").getString("ERROR"), JOptionPane.ERROR_MESSAGE);
+          dialog.showErrorMessage(ex, java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/resources/CamCalibrationDialog").getString("ERROR LOADING IMAGE:"));
         }
   }
 
@@ -466,7 +468,7 @@ private void sendButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FI
   }
   catch (Exception e)
   {
-    JOptionPane.showMessageDialog(this, java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/resources/CamCalibrationDialog").getString("ERROR SENDING PAGE: ") + e.getLocalizedMessage(), java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/resources/CamCalibrationDialog").getString("ERROR"), JOptionPane.ERROR_MESSAGE);
+    dialog.showErrorMessage(e, java.util.ResourceBundle.getBundle("com/t_oster/visicut/gui/resources/CamCalibrationDialog").getString("ERROR SENDING PAGE: "));
   }
 }//GEN-LAST:event_sendButtonActionPerformed
 

--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -159,51 +159,45 @@ public class MainView extends javax.swing.JFrame
     @Override
     public void showWarningMessage(String text)
     {
-      MainView.this.warningPanel.addMessage(new Message("Warning", text, Message.Type.WARNING, null));
+      MainView.this.warningPanel.addMessage(new Message(bundle.getString("WARNING"), text, Message.Type.WARNING, null));
     }
 
     @Override
     public void showWarningMessageOnce(String text, String messageId, int timeout)
     {
       // use timeout=-1 to disable timeout
-      MainView.this.warningPanel.addMessageOnce(new Message("Warning", text, Message.Type.WARNING, null, timeout), messageId);
+      MainView.this.warningPanel.addMessageOnce(new Message(bundle.getString("WARNING"), text, Message.Type.WARNING, null, timeout), messageId);
     }
 
     @Override
     public void showSuccessMessage(String text)
     {
-      MainView.this.warningPanel.addMessage(new Message("Success", text, Message.Type.SUCCESS, null, 10000));
+      MainView.this.warningPanel.addMessage(new Message(bundle.getString("SUCCESS"), text, Message.Type.SUCCESS, null, 10000));
     }
 
     @Override
     public void showInfoMessage(String text)
     {
-      MainView.this.warningPanel.addMessage(new Message("Info", text, Message.Type.INFO, null));
+      MainView.this.warningPanel.addMessage(new Message(bundle.getString("INFO"), text, Message.Type.INFO, null));
     }
 
     @Override
     public void showErrorMessage(Exception ex)
     {
-      Throwable cause = ex;
-      while ((cause.getMessage() == null || "".equals(cause.getMessage())) && cause.getCause() != null)
-      {
-        cause = cause.getCause();
-      }
-      cause.printStackTrace();
-      MainView.this.warningPanel.addMessage(new Message("Error", "Exception: " + cause.getLocalizedMessage(), Message.Type.ERROR, null));
+      this.showErrorMessage(ex, null);
     }
 
     @Override
     public void showErrorMessage(Exception cause, String text)
     {
       cause.printStackTrace();
-      MainView.this.warningPanel.addMessage(new Message("Error", text + ": " + cause.getLocalizedMessage(), Message.Type.ERROR, null));
+      this.showErrorMessage(DialogHelper.getHumanReadableErrorMessage(cause, text));
     }
 
     @Override
     public void showErrorMessage(String text)
     {
-      MainView.this.warningPanel.addMessage(new Message("Error", text, Message.Type.ERROR, null));
+      MainView.this.warningPanel.addMessage(new Message(bundle.getString("ERROR"), text, Message.Type.ERROR, null));
     }
 
     @Override
@@ -2579,18 +2573,7 @@ private void executeJobMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
               }
               catch (Exception e)
               {
-                e.printStackTrace();
-                if (e instanceof java.net.SocketException)
-                {
-                  // Network errors like "port not found" have meaningful error messages
-                  msg = e.getLocalizedMessage();
-                }
-                else
-                {
-                  // Most other exceptions are not easy to understand without the class name
-                  // (e.g. 'java.net.UnknownHostException: foo.example.com')
-                  msg = ex.getClass().getSimpleName() + ": " + ex.getLocalizedMessage();
-                }
+                msg = DialogHelper.getHumanReadableErrorMessage(e);
               }
               if (responseCode != 0)
               {
@@ -2611,7 +2594,7 @@ private void executeJobMenuItemActionPerformed(java.awt.event.ActionEvent evt) {
             }
             else
             {
-              cameraCapturingError = bundle.getString("ERROR CAPTURING PHOTO") + "\nError (" + ex.getClass().getSimpleName() + "): " + ex.getLocalizedMessage();
+              cameraCapturingError = DialogHelper.getHumanReadableErrorMessage(ex, bundle.getString("ERROR CAPTURING PHOTO"));
             }
           }
 

--- a/src/com/t_oster/visicut/gui/resources/MainView.properties
+++ b/src/com/t_oster/visicut/gui/resources/MainView.properties
@@ -155,3 +155,6 @@ DIALOG_QUESTION_FABQR_UPLOAD=Do you want to upload your project to the websites 
 DIALOG_QUESTION_EXPORT_PASSWORD=Passwords will be contained in the exported file.\nDo you really want to continue?
 wikiMenuItem.text=Wiki
 manualMenuItem.text=Manual
+ERROR=Error
+INFO=Information
+SUCCESS=Success

--- a/src/com/t_oster/visicut/gui/resources/MainView_de_DE.properties
+++ b/src/com/t_oster/visicut/gui/resources/MainView_de_DE.properties
@@ -140,3 +140,6 @@ webcamQRCodeMenuItem.text=Webcam: QR code scannen
 btQRWebcamScan.toolTipText=Scanne QR Codes mit der Webcam
 DIALOG_QUESTION_FABQR_UPLOAD=Soll dieses Projekt auf den Websiten des FabLabs ver\u00f6ffentlicht werden?
 DIALOG_QUESTION_EXPORT_PASSWORD=Passw\u00f6rter werden in der exportierten Datei enthalten sein.\nVorgang wirklich fortsetzen?
+ERROR=Fehler
+INFO=Information
+SUCCESS=Erfolg

--- a/src/com/t_oster/visicut/gui/resources/MainView_fr_FR.properties
+++ b/src/com/t_oster/visicut/gui/resources/MainView_fr_FR.properties
@@ -155,3 +155,6 @@ DIALOG_QUESTION_FABQR_UPLOAD=Voulez vous envoyer votre projet sur le site web de
 DIALOG_QUESTION_EXPORT_PASSWORD=Les mots de passes seront export\u00e9s en clair dans le fichier d\u2019export, et lisible par n\u2019importe qui ouvrant le fichier.\nEtes vous sure de vouloir continuer?
 wikiMenuItem.text=Wiki
 manualMenuItem.text=Manuel
+ERROR=Erreur
+INFO=Information
+SUCCESS=Succ\u00e8s

--- a/src/com/t_oster/visicut/gui/resources/MainView_it_IT.properties
+++ b/src/com/t_oster/visicut/gui/resources/MainView_it_IT.properties
@@ -155,3 +155,6 @@ DIALOG_QUESTION_FABQR_UPLOAD=Vuoi caricare il tuo progetto sul sito web del tuo 
 DIALOG_QUESTION_EXPORT_PASSWORD=Le Passwords saranno contenute nel file esportato.\nVuoi veramente continuare?
 wikiMenuItem.text=Wiki
 manualMenuItem.text=Manuale
+ERROR=Errore
+INFO=Information
+SUCCESS=Success

--- a/src/com/t_oster/visicut/gui/resources/MainView_nl_NL.properties
+++ b/src/com/t_oster/visicut/gui/resources/MainView_nl_NL.properties
@@ -125,3 +125,6 @@ webcamQRCodeMenuItem.text=Webcam: QR code scannen
 btQRWebcamScan.toolTipText=Scan QR codes met de webcam
 DIALOG_QUESTION_FABQR_UPLOAD=Wilt u uw project te uploaden naar de websites van uw FabLab?
 DIALOG_QUESTION_EXPORT_PASSWORD=Wachtwoorden zullen worden opgenomen in het ge\u00ebxporteerde bestand.\nProces echt doorgaan?
+ERROR=Fout
+INFO=Information
+SUCCESS=Success

--- a/src/com/t_oster/visicut/misc/DialogHelper.java
+++ b/src/com/t_oster/visicut/misc/DialogHelper.java
@@ -204,10 +204,67 @@ public class DialogHelper
     this.showErrorMessage(cause, "");
   }
 
+  /**
+   * Show a human-readable but useful message for an exception.
+   * @param cause Exception
+   * @param text Error message
+   */
   public void showErrorMessage(Exception cause, String text)
   {
     cause.printStackTrace();
-    JOptionPane.showMessageDialog(parent, text + "\nError (" + cause.getClass().getSimpleName() + "): " + cause.getLocalizedMessage(), title + " Error", JOptionPane.ERROR_MESSAGE);
+    String message = getHumanReadableErrorMessage(cause, text);
+    JOptionPane.showMessageDialog(parent, message, title + " Error", JOptionPane.ERROR_MESSAGE);
+  }
+
+    /**
+   * Generate a human-readable but useful message for an exception.
+   * Also print the stack trace to stdout.
+   * @param cause Exception
+   * @param text Error message (optional)
+   * @return Message string useful for showing in an error dialog
+   */
+  public static String getHumanReadableErrorMessage(Exception cause, String text)
+  {
+    cause.printStackTrace();
+    String message = "";
+    if (text != null && text.length() > 0)
+    {
+      message = text + "\n";
+    }
+    // display the localized message (such as "No route to host") if there is one
+    // otherwise show the class name
+    if (cause.getLocalizedMessage() == null)
+    {
+      message = message + cause.getClass().getSimpleName();
+    }
+    else
+    {
+      if (cause instanceof java.net.SocketException)
+      {
+        // Network errors like "port not found" have meaningful error messages
+        message = message + cause.getLocalizedMessage();
+      }
+      else
+      {
+        // Most other exceptions are not easy to understand without the class name
+        // (e.g. 'java.net.UnknownHostException: foo.example.com')
+        message = message + cause.getClass().getSimpleName() + ": " + cause.getLocalizedMessage();
+      }
+    }
+    // for interesting exceptions, add the first few stack trace lines
+    if (cause.getClass().equals(NullPointerException.class))
+    {
+      StackTraceElement[] stackTrace = cause.getStackTrace();
+      for (int i = 0; i < 2 && i < stackTrace.length; i++)
+      {
+        message = message + "\n" + stackTrace[i].toString();
+      }
+    }
+    return message;
+  }
+
+  public static String getHumanReadableErrorMessage(Exception cause) {
+    return getHumanReadableErrorMessage(cause, null);
   }
 
   public void showErrorMessage(String text)


### PR DESCRIPTION
Make them more detailed for unusual ones (NullPointerException), and less detailed for others (No route to host).
Also translate the error message titles (TODO: translate to IT/NL/FR)
and always print a stack trace (in many cases, printStackTrace is now called twice, but IMHO that doesn't really matter)

Helps with debugging "Error: null" as in #295 

This is not entirely tested. It should not crash (that would be slightly embarassing), but it may show too long or too short messages in some cases.