### PR TITLE
Fix more null pointer exceptions caused by thread-safety problems

### DIFF
--- a/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGImage.java
+++ b/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGImage.java
@@ -20,9 +20,9 @@ package com.t_oster.visicut.model.graphicelements.svgsupport;
 
 import com.kitfox.svg.ImageSVG;
 import com.kitfox.svg.RenderableElement;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  *
@@ -44,7 +44,8 @@ public class SVGImage extends SVGObject
     return decoratee;
   }
 
-  private Map<String,List<Object>> attributeValues = new LinkedHashMap<String,List<Object>>();
+  // needs to be threadsafe, see note in SVGObject
+  private Map<String,List<Object>> attributeValues = new ConcurrentHashMap<String,List<Object>>();
   @Override
   public List<Object> getAttributeValues(String attribute)
   {

--- a/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGObject.java
+++ b/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGObject.java
@@ -75,7 +75,6 @@ public abstract class SVGObject implements GraphicObject
    * applies all transformations in the Path of the SVGShape
    * and returns the Transformed Shape, which can be displayed
    * or printed on the position it appears in the original image.
-   * @param selectedSVGElement
    * @return 
    */
   public AffineTransform getAbsoluteTransformation() throws SVGException
@@ -183,15 +182,17 @@ public abstract class SVGObject implements GraphicObject
     attributeValues.put(name, result);
     return result;
   }
-  private List<String> attributes = null;
+
+  // cached return value of getAttributes()
+  private List<String> attributesCache = null;
 
   public List<String> getAttributes()
   {
-    if (attributes != null)
+    if (attributesCache != null)
     {
-      return attributes;
+      return attributesCache;
     }
-    attributes = new LinkedList<String>();
+    LinkedList<String> attributes = new LinkedList<String>();
     for (Attribute a : Attribute.values())
     {
       if (this.getAttributeValues(a.toString()).size() > 0)
@@ -199,7 +200,10 @@ public abstract class SVGObject implements GraphicObject
         attributes.add(a.toString().replace("_", " "));
       }
     }
-    return attributes;
+    // late assignment for thread-safety:
+    // prevent other threads from accessing the list while it is being constructed
+    attributesCache = attributes;
+    return attributesCache;
   }
 
   /**


### PR DESCRIPTION
Now GraphicSet and its most important subclasses should be correctly threadsafe.