### PR TITLE
Engrave preview and multiple other improvements

### DIFF
--- a/distribute/distribute.sh
+++ b/distribute/distribute.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e # exit 1 if any command fails
+cd "$(dirname "$0")"
 # set -x # uncomment for debugging
 if [ "$1" == "--nocompile" ]
 then
@@ -7,8 +8,8 @@ then
 else
    COMPILE=1
 fi
-echo "Determining Version:"
-VERSION=$(cat ../src/com/t_oster/visicut/gui/resources/VisicutApp.properties |grep Application.version)
+echo "Determining Version (may be overriden with environment variable VERSION):"
+VERSION=${VERSION:-$(cat ../src/com/t_oster/visicut/gui/resources/VisicutApp.properties |grep Application.version)}
 VERSION=${VERSION#*=}
 VERSION=${VERSION// /}
 echo "Version is: \"$VERSION\""

--- a/distribute/files/VisiCut.Linux
+++ b/distribute/files/VisiCut.Linux
@@ -7,4 +7,4 @@ port=${DISPLAY##*:}
 port=${port%.*}
 # add it to the instance-port
 let port=port+6543
-java -Xms256m -Xmx1024m -jar "$DIR/Visicut.jar" --singleinstanceport $port "$@"
+java -Xms256m -Xmx2048m -jar "$DIR/Visicut.jar" --singleinstanceport $port "$@"

--- a/distribute/files/VisiCut.MacOS
+++ b/distribute/files/VisiCut.MacOS
@@ -1,3 +1,3 @@
 #!/bin/bash
 DIR="$( cd -P "$( dirname "$0" )" && pwd )"
-java -Xms256m -Xmx1024m -jar "$DIR/Visicut.jar" --singleinstanceport 6543 "$@"
+java -Xms256m -Xmx2048m -jar "$DIR/Visicut.jar" --singleinstanceport 6543 "$@"

--- a/distribute/windows/launcher.nsi
+++ b/distribute/windows/launcher.nsi
@@ -11,62 +11,182 @@ SilentInstall silent
 AutoCloseWindow true
 ShowInstDetails nevershow
 RequestExecutionLevel user
+; uncomment next two lines to show debug output (DetailPrint messages). Also uncomment the "DEBUG" message later in this file to force the setup to wait before exiting.
+; ShowInstDetails show
+; SilentInstall normal
  
 ;You want to change the next two lines too
 !define CLASSPATH ".;lib"
 !define JARFILE "Visicut.jar"
-!define VMARGS "-Xms256m -Xmx2048m"
 !define PRGARGS "--singleinstanceport 6543"
 
 !include "FileFunc.nsh"
+!include LogicLib.nsh
 !insertmacro GetParameters
- 
+
+Var /GLOBAL maximumJavaRAM
+Var /GLOBAL s_SystemMemoryMB
+Var /GLOBAL s_SystemMemoryGB
+Var /GLOBAL ARGV
+
 Section ""
-  Call GetJRE
+  ${GetParameters} $ARGV
+  DetailPrint "argv = $ARGV"
+
+  StrCmp $ARGV "--debug" 0 +3
+  ; if commandline is "--debug": show JRE with console
+    Call GetJREConsole
+    Goto +2
+  ; else:
+    ; show JRE without console
+    Call GetJRE
+  ; end
   Pop $R0
 
-  ${GetParameters} $1 
-  ; change for your purpose (-jar etc.)
-  StrCpy $0 '"$R0" ${VMARGS} -classpath "${CLASSPATH}" -jar ${JARFILE} ${PRGARGS} $1'
- 
- 
-  SetOutPath $EXEDIR
-  ExecWait $0
+  Call s_QuerySystemMemory
+  DetailPrint "system RAM $s_SystemMemoryMB MB"
+
+  ; maximumJavaRAM= systemRAM / 2
+  IntOp $maximumJavaRAM $s_SystemMemoryMB / 2
+
+  ; TODO: the reported sy
+  ; limit maximumJavaRAM to 4GB (should be enough for everything)
+  ${If} $maximumJavaRAM > 4096
+    StrCpy $maximumJavaRAM "4096"
+  ${EndIf}
+  DetailPrint "choosing java RAM limit = $maximumJavaRAM MB"
+
+
+  Call startVisicut
+
+  IfErrors 0 end
+  ; if errors: retry with lower RAM (workaround if the JVM is 32bit or too stupid to allocate some memory)
+    DetailPrint "failed (maybe Java couldn't start because the RAM size was set too high). retrying with smaller RAM."
+    StrCpy $maximumJavaRAM "1024"
+    Call startVisicut
+  end:
+  ; if no errors: just exit.
+
+  ; uncomment to wait before end
+  ; MessageBox MB_OK "DEBUG"
 SectionEnd
  
+Function startVisicut
+  Var /GLOBAL VMARGS
+  StrCpy $2 $maximumJavaRAM
+  DetailPrint "java ram: $2 MB"
+  StrCpy $VMARGS "-Xms256m -Xmx$2m"
+  StrCpy $0 '"$R0" $VMARGS -classpath "${CLASSPATH}" -jar ${JARFILE} ${PRGARGS} $ARGV'
+  SetOutPath $EXEDIR
+  ExecWait $0
+FunctionEnd
+ 
 Function GetJRE
+  push "javaw.exe"
+  call GetJREPath
+FunctionEnd
+
+Function GetJREConsole
+  push "java.exe"
+  call GetJREPath
+FunctionEnd
+
+
+# Ask the system for how much memory it has available. When finished,
+# the variables $s_SystemMemoryMB and $s_SystemMemoryGB will be initialized
+# LICENSE for this function:
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+Function s_QuerySystemMemory
+    # We will need to use variables $0 through $9, so save away any existing values.
+    Push $0
+    Push $1
+    Push $2
+    Push $3
+    Push $4
+    Push $5
+    Push $6
+    Push $7
+    Push $8
+    Push $9
+
+    # Call GlobalMemoryStatusEx using the System plugin.
+    # For more info: http://nsis.sourceforge.net/Docs/System/System.html
+    System::Alloc 64
+    Pop $0
+    # GlobalMemoryStatusEx requires the first parameter to be the size
+    # of the whole structure. Everything else is zeroed out.
+    System::Call "*$0(i 64, i 0, l 0, l 0, l 0, l 0, l 0, l 0, l 0)"
+    System::Call "Kernel32::GlobalMemoryStatusEx(i r0)" # Read status into $0
+    System::Call "*$0(i.r1, i.r2, l.r3, l.r4, l.r5, l.r6, l.r7, l.r8, l.r9)"
+    # Machine's physical memory value (in bytes) is the third parameter. See MSDN:
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa366770(v=vs.85).aspx
+    System::Int64Op $3 / 1048576 # 1024 * 1024
+    Pop $s_SystemMemoryMB
+    System::Int64Op $s_SystemMemoryMB / 1024
+    Pop $s_SystemMemoryGB
+    System::Free $0
+
+    # Restore old values
+    Pop $9
+    Pop $8
+    Pop $7
+    Pop $6
+    Pop $5
+    Pop $4
+    Pop $3
+    Pop $2
+    Pop $1
+    Pop $0
+
+FunctionEnd
+
+Function GetJREPath
 ;
-;  Find JRE (javaw.exe)
+;  Find JRE path (parameter 0: java.exe or javaw.exe)
 ;  1 - in .\jre directory (JRE Installed with application)
 ;  2 - in JAVA_HOME environment variable
 ;  3 - in the registry
 ;  4 - assume javaw.exe in current dir or PATH
- 
+  Pop $0
   Push $R0
   Push $R1
  
   ClearErrors
-  StrCpy $R0 "$EXEDIR\jre\bin\javaw.exe"
+  StrCpy $R0 "$EXEDIR\jre\bin\$0"
   IfFileExists $R0 JreFound
   StrCpy $R0 ""
 
   ClearErrors
   ReadEnvStr $R0 "JAVA_HOME"
-  StrCpy $R0 "$R0\bin\javaw.exe"
+  StrCpy $R0 "$R0\bin\$0"
   IfErrors 0 JreFound
 
   ClearErrors
   SetRegView 64
   ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
   ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$R1" "JavaHome"
-  StrCpy $R0 "$R0\bin\javaw.exe"
+  StrCpy $R0 "$R0\bin\$0"
 
   IfErrors 0 JreFound
 
   ClearErrors
   ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\Java Development Kit" "CurrentVersion"
   ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\Java Development Kit\$R1" "JavaHome"
-  StrCpy $R0 "$R0\bin\javaw.exe"
+  StrCpy $R0 "$R0\bin\$0"
 
   IfErrors 0 JreFound
 
@@ -74,17 +194,17 @@ Function GetJRE
   SetRegView 32
   ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment" "CurrentVersion"
   ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\Java Runtime Environment\$R1" "JavaHome"
-  StrCpy $R0 "$R0\bin\javaw.exe"
+  StrCpy $R0 "$R0\bin\$0"
 
   IfErrors 0 JreFound
 
   ClearErrors
   ReadRegStr $R1 HKLM "SOFTWARE\JavaSoft\Java Development Kit" "CurrentVersion"
   ReadRegStr $R0 HKLM "SOFTWARE\JavaSoft\Java Development Kit\$R1" "JavaHome"
-  StrCpy $R0 "$R0\bin\javaw.exe"
+  StrCpy $R0 "$R0\bin\$0"
 
   IfErrors 0 JreFound
-  StrCpy $R0 "javaw.exe"
+  StrCpy $R0 "$0"
  
  JreFound:
   Pop $R1

--- a/distribute/windows/launcher.nsi
+++ b/distribute/windows/launcher.nsi
@@ -15,7 +15,7 @@ RequestExecutionLevel user
 ;You want to change the next two lines too
 !define CLASSPATH ".;lib"
 !define JARFILE "Visicut.jar"
-!define VMARGS "-Xms256m -Xmx1024m"
+!define VMARGS "-Xms256m -Xmx2048m"
 !define PRGARGS "--singleinstanceport 6543"
 
 !include "FileFunc.nsh"

--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -178,7 +178,7 @@ run.classpath=\
 # Space-separated list of JVM arguments used when running the project
 # (you may also define separate properties like run-sys-prop.name=value instead of -Dname=value
 # or test-sys-prop.name=value to set system properties for unit tests):
-run.jvmargs=-Xms128m -Xmx1024m
+run.jvmargs=-Xms128m -Xmx2048m
 run.test.classpath=\
     ${javac.test.classpath}:\
     ${build.test.classes.dir}

--- a/src/com/t_oster/visicut/VisicutModel.java
+++ b/src/com/t_oster/visicut/VisicutModel.java
@@ -762,7 +762,11 @@ public class VisicutModel
           continue;
         }
         List<LaserProperty> props = propmap.get(pr);
-        pr.addToLaserJob(job, set, this.addFocusOffset(props, focusOffset));
+        try {
+          pr.addToLaserJob(job, set, this.addFocusOffset(props, focusOffset));
+        } catch (InterruptedException ex) {
+          throw new RuntimeException("this must not happen");
+        }
       }
     }
     return job;

--- a/src/com/t_oster/visicut/gui/CamCalibrationDialog.java
+++ b/src/com/t_oster/visicut/gui/CamCalibrationDialog.java
@@ -119,6 +119,9 @@ public class CamCalibrationDialog extends javax.swing.JDialog
           if (src != null)
           {
             URLConnection conn = src.openConnection();
+            conn.setConnectTimeout(5 * 1000); // 5s connect timeout
+            conn.setReadTimeout(30 * 1000); // 30s read timeout after connecting
+
 
             // HTTP authentication
             if (VisicutModel.getInstance() != null && VisicutModel.getInstance().getSelectedLaserDevice() != null)
@@ -150,6 +153,9 @@ public class CamCalibrationDialog extends javax.swing.JDialog
 
   private void refreshImagePoints()
   {
+    if (backgroundImage == null) {
+      return;
+    }
     int numPriorPoints = 0;
     if (modifiedImagePoints == null) {
       modifiedImagePoints = new Point2D.Double[numAlignmentPoints];

--- a/src/com/t_oster/visicut/gui/beans/resources/PreviewPanel.properties
+++ b/src/com/t_oster/visicut/gui/beans/resources/PreviewPanel.properties
@@ -1,5 +1,4 @@
-# To change this template, choose Tools | Templates
-# and open the template in the editor.
+# To change this file, choose "Open" in NetBeans Context menu
 
 ERROR\:\ NOT\ ENOUGH\ MEMORY\ PLEASE\ START\ THE\ PROGRAM\ FROM\ THE\ PROVIDED\ SHELL\ SCRIPTS\ INSTEAD\ OF\ RUNNING\ THE\ .JAR\ FILE=Error: Not enough Memory\nPlease start the Program from the provided shell scripts instead of running the .jar file
 NO\ MATCHING\ PARTS\ FOR\ THE\ CURRENT\ MAPPING\ FOUND.=No matching parts for the current Mapping found.

--- a/src/com/t_oster/visicut/misc/DialogHelper.java
+++ b/src/com/t_oster/visicut/misc/DialogHelper.java
@@ -215,15 +215,26 @@ public class DialogHelper
     String message = getHumanReadableErrorMessage(cause, text);
     JOptionPane.showMessageDialog(parent, message, title + " Error", JOptionPane.ERROR_MESSAGE);
   }
-
     /**
    * Generate a human-readable but useful message for an exception.
    * Also print the stack trace to stdout.
    * @param cause Exception
    * @param text Error message (optional)
    * @return Message string useful for showing in an error dialog
+  */
+    public static String getHumanReadableErrorMessage(Throwable cause, String text) {
+      return getHumanReadableErrorMessage(cause, text, false);
+    }
+
+    /**
+   * Generate a human-readable but useful message for an exception.
+   * Also print the stack trace to stdout.
+   * @param cause Exception
+   * @param text Error message (optional)
+   * @param alwaysShowStacktrace force that a stacktrace is shown (if false: stacktrace is hidden for well-known exceptions such as "Host not found")
+   * @return Message string useful for showing in an error dialog
    */
-  public static String getHumanReadableErrorMessage(Exception cause, String text)
+  public static String getHumanReadableErrorMessage(Throwable cause, String text, boolean alwaysShowStacktrace)
   {
     cause.printStackTrace();
     String message = "";
@@ -253,7 +264,8 @@ public class DialogHelper
     }
     // for interesting exceptions, add the first few stack trace lines
     boolean emptyMessage = cause.getMessage() == null || cause.getMessage().trim().length() == 0;
-    if (cause.getClass().equals(NullPointerException.class) ||
+    if (alwaysShowStacktrace ||
+        cause.getClass().equals(NullPointerException.class) ||
         (cause.getClass().equals(Exception.class) && emptyMessage))
     {
       StackTraceElement[] stackTrace = cause.getStackTrace();
@@ -265,7 +277,7 @@ public class DialogHelper
     return message;
   }
 
-  public static String getHumanReadableErrorMessage(Exception cause) {
+  public static String getHumanReadableErrorMessage(Throwable cause) {
     return getHumanReadableErrorMessage(cause, null);
   }
 

--- a/src/com/t_oster/visicut/misc/DialogHelper.java
+++ b/src/com/t_oster/visicut/misc/DialogHelper.java
@@ -266,6 +266,8 @@ public class DialogHelper
     boolean emptyMessage = cause.getMessage() == null || cause.getMessage().trim().length() == 0;
     if (alwaysShowStacktrace ||
         cause.getClass().equals(NullPointerException.class) ||
+        cause.getClass().equals(ArrayIndexOutOfBoundsException.class) ||
+        cause.getClass().equals(ClassCastException.class) ||
         (cause.getClass().equals(Exception.class) && emptyMessage))
     {
       StackTraceElement[] stackTrace = cause.getStackTrace();

--- a/src/com/t_oster/visicut/model/LaserProfile.java
+++ b/src/com/t_oster/visicut/model/LaserProfile.java
@@ -132,9 +132,9 @@ public abstract class LaserProfile implements ImageListable, Cloneable
   //with old XML files
   private transient boolean temporaryCopy;
   
-  public abstract void renderPreview(Graphics2D g, GraphicSet objects, MaterialProfile material, AffineTransform mm2px);
+  public abstract void renderPreview(Graphics2D g, GraphicSet objects, MaterialProfile material, AffineTransform mm2px) throws InterruptedException;
 
-  public abstract void addToLaserJob(LaserJob job, GraphicSet objects, List<LaserProperty> laserProperties);
+  public abstract void addToLaserJob(LaserJob job, GraphicSet objects, List<LaserProperty> laserProperties) throws InterruptedException;
 
   @Override
   public String toString()

--- a/src/com/t_oster/visicut/model/Raster3dProfile.java
+++ b/src/com/t_oster/visicut/model/Raster3dProfile.java
@@ -94,7 +94,7 @@ public class Raster3dProfile extends LaserProfile
     this.colorShift = colorShift;
   }
 
-  public BufferedImage getRenderedPreview(GraphicSet objects, MaterialProfile material, AffineTransform mm2px, ProgressListener pl)
+  public BufferedImage getRenderedPreview(GraphicSet objects, MaterialProfile material, AffineTransform mm2px, ProgressListener pl) throws InterruptedException
   {
     Rectangle bb = Helper.toRect(Helper.transform(objects.getBoundingBox(), mm2px));
     if (bb != null && bb.width > 0 && bb.height > 0)
@@ -139,6 +139,9 @@ public class Raster3dProfile extends LaserProfile
         }
         if (pl != null)
         {
+          if (Thread.interrupted()) {
+            throw new InterruptedException();
+          }
           pl.progressChanged(this, 100 * y / ad.getHeight());
         }
       }
@@ -148,12 +151,12 @@ public class Raster3dProfile extends LaserProfile
   }
   
   @Override
-  public void renderPreview(Graphics2D gg, GraphicSet objects, MaterialProfile material, AffineTransform mm2px)
+  public void renderPreview(Graphics2D gg, GraphicSet objects, MaterialProfile material, AffineTransform mm2px) throws InterruptedException
   {
     this.renderPreview(gg, objects, material, mm2px, null);
   }
 
-  public void renderPreview(Graphics2D gg, GraphicSet objects, MaterialProfile material, AffineTransform mm2px, ProgressListener pl)
+  public void renderPreview(Graphics2D gg, GraphicSet objects, MaterialProfile material, AffineTransform mm2px, ProgressListener pl) throws InterruptedException
   {
     Rectangle bb = Helper.toRect(Helper.transform(objects.getBoundingBox(), mm2px));
     BufferedImage scaledImg = this.getRenderedPreview(objects, material, mm2px, pl);

--- a/src/com/t_oster/visicut/model/RasterProfile.java
+++ b/src/com/t_oster/visicut/model/RasterProfile.java
@@ -127,7 +127,7 @@ public class RasterProfile extends LaserProfile
     this.ditherAlgorithm = ditherAlgorithm;
   }
 
-  public BufferedImage getRenderedPreview(GraphicSet objects, MaterialProfile material, AffineTransform mm2px)
+  public BufferedImage getRenderedPreview(GraphicSet objects, MaterialProfile material, AffineTransform mm2px) throws InterruptedException
   {
     return this.getRenderedPreview(objects, material, mm2px, null);
   }
@@ -159,7 +159,7 @@ public class RasterProfile extends LaserProfile
     return scaledImg;
   }
 
-  public BufferedImage getRenderedPreview(GraphicSet objects, MaterialProfile material, AffineTransform mm2px, ProgressListener pl)
+  public BufferedImage getRenderedPreview(GraphicSet objects, MaterialProfile material, AffineTransform mm2px, ProgressListener pl) throws InterruptedException
   {
     Rectangle bb = Helper.toRect(Helper.transform(objects.getBoundingBox(), mm2px));
     final Color engraveColor = material.getEngraveColor();
@@ -210,7 +210,7 @@ public class RasterProfile extends LaserProfile
 }
 
   @Override
-  public void renderPreview(Graphics2D gg, GraphicSet objects, MaterialProfile material, AffineTransform mm2px)
+  public void renderPreview(Graphics2D gg, GraphicSet objects, MaterialProfile material, AffineTransform mm2px) throws InterruptedException
   {
     Rectangle2D bb = Helper.transform(objects.getBoundingBox(), mm2px);
     if (bb != null && bb.getWidth() > 0 && bb.getHeight() > 0)
@@ -221,7 +221,7 @@ public class RasterProfile extends LaserProfile
   }
 
   @Override
-  public void addToLaserJob(LaserJob job, GraphicSet set, List<LaserProperty> laserProperties)
+  public void addToLaserJob(LaserJob job, GraphicSet set, List<LaserProperty> laserProperties) throws InterruptedException
   {
     double factor = Util.dpi2dpmm(this.getDPI());
     AffineTransform mm2laserPx = AffineTransform.getScaleInstance(factor, factor);


### PR DESCRIPTION
This is an addition to my previous pullrequest (will rebase as soon as the other one is merged) with more discussion-worthy changes.

1. better antialiasing for the engrave preview by switching to a downscaled image if the user zooms out far enough
2. save some RAM by storing the (non-downscaled) raster preview as 1bit indexed (1 byte per pixel instead of 1 integer per pixel)
3. The heaviest change of this: switch from Thread.stop() to Thread.interrupt(), and dozens of interface changes to make the dithering interruptable and pass on InterruptedException. To be used together with the LibLaserCut pullrequest https://github.com/t-oster/LibLaserCut/pull/90 (compiles and works without, but the dithering will just go on without being interrupted). 

Please give feedback if this is the right approach and if you feel these are ready for merging. Testing is highly appreciated, I don't know how many stupid edge cases there are which I couldn't find. Mac is entirely untested, I will test Windows soon, but have no Mac. I suspect some graphics rendering stuff may be different on Mac.

Maybe a feature branch would be a good idea, so that others can easily test?