### PR TITLE
Bugfix: Missing thickness in fallback example settings

### DIFF
--- a/src/com/t_oster/visicut/managers/PreferencesManager.java
+++ b/src/com/t_oster/visicut/managers/PreferencesManager.java
@@ -36,7 +36,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -117,12 +119,14 @@ public final class PreferencesManager
       mp.setColor(Color.WHITE);
       mp.setCutColor(Color.RED);
       mp.setEngraveColor(Color.DARK_GRAY);
+      mp.setMaterialThicknesses(new LinkedList<Float>(Arrays.asList(new Float(1.0))));
       MaterialManager.getInstance().add(mp);
       mp = new MaterialProfile();
       mp.setName("Acrylic");
       mp.setColor(Color.BLUE);
       mp.setCutColor(Color.RED);
       mp.setEngraveColor(Color.WHITE);
+      mp.setMaterialThicknesses(new LinkedList<Float>(Arrays.asList(new Float(1.0))));
       MaterialManager.getInstance().add(mp);
       preferences.setLastMaterial(mp.getName());
     }


### PR DESCRIPTION
The fallback example settings (if no example directory was found, e.g. when starting from the source directory) did not create a material thickness, which triggered a warning.

Reproduce:
- Launch visicut via NetBeans IDE (or `ant run`)
- Options -> Download recommended settings  -> Example settings.
- Close and reopen
- Warning: Found material "Acrylic" without a thickness entry - this should not happen! Adding a thickness 0.0 for this material. Please report if you find a way to create materials without a thickness.