### PR TITLE
Fix order of concatentation of nested transforms

### DIFF
--- a/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGObject.java
+++ b/src/com/t_oster/visicut/model/graphicelements/svgsupport/SVGObject.java
@@ -26,6 +26,7 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -82,11 +83,13 @@ public abstract class SVGObject implements GraphicObject
     if (this.getDecoratee() != null)
     {
       AffineTransform tr = new AffineTransform();
-      for (Object o : this.getPathToRoot())
+      List<SVGElement> pathToRoot = this.getPathToRoot();
+      Collections.reverse(pathToRoot);
+      for (Object o : pathToRoot)
       {
         if (o instanceof Group)
         {
-          StyleAttribute sty = new StyleAttribute("transform"); 
+          StyleAttribute sty = new StyleAttribute("transform");
           if (((SVGElement) o).getPres(sty))
           {
             String value = sty.getStringValue();
@@ -96,8 +99,7 @@ public abstract class SVGObject implements GraphicObject
               if (!"".equals(v))
               {
                 AffineTransform trans = SVGElement.parseSingleTransform(v+")");
-                trans.concatenate(tr);
-                tr = trans;
+                tr.concatenate(trans);
               }
             }
           }


### PR DESCRIPTION
Users of kyub.com report problems with VisiCut, because there was a bug with nested transformed groups. kyub exports SVG files with lots of such groups e.g. the numbers for assembly instructions.

<details><summary>Example SVG</summary>
<p>

```svg
<?xml version="1.0"?>
<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
<svg version="1.1" encoding="utf-8" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="841mm" height="594mm" viewBox="0 0 841 594">
  <!-- Generator: KYUB Editor - kyub.com -->
  <style type="text/css">.instructions {stroke:blue; stroke-width:0.01; fill:none}</style>
  <g transform="translate(58.53,101.64) rotate(0)">
    <path d="M-49.994,-10.639 L-48.011,-10.639 L-46.074,-10.714 L-44.173,-10.936 L-42.278,-11.311 L-40.437,-11.83 L-39.806,-12.062 L-38.282,-7.934 L-36.94,-8.43 L-34.886,-9.378 L-32.906,-10.489 L-31.028,-11.747 L-30.126,-12.459 L-32.853,-15.913 L-32.102,-16.504 L-30.695,-17.806 L-29.393,-19.213 L-28.196,-20.73 L-27.203,-22.214 L-23.547,-19.766 L-23.38,-20.014 L-22.265,-22.001 L-21.319,-24.051 L-20.529,-26.19 L-19.918,-28.365 L-19.858,-28.667 L-24.174,-29.522 L-23.825,-31.284 L-23.603,-33.183 L-23.528,-35.116 L-23.528,-40.245 L-19.128,-40.245 L-19.128,-44.992 L-23.528,-44.992 L-23.528,-50.019 L-23.532,-50.019 L-23.528,-50.123 L-23.528,-50.259 L-23.523,-50.259 L-23.375,-54.092 L-23.138,-56.118 L-18.767,-55.606 L-18.564,-57.347 L-17.885,-60.778 L-22.2,-61.632 L-22.144,-61.923 L-21.069,-65.741 L-20.413,-67.52 L-16.285,-65.996 L-15.628,-67.776 L-14.223,-70.818 L-18.217,-72.663 L-18.033,-73.064 L-16.091,-76.523 L-15.118,-77.977 L-11.462,-75.53 L-10.324,-77.229 L-8.337,-79.746 L-11.791,-82.473 L-11.427,-82.933 L-8.734,-85.845 L-7.556,-86.935 L-4.569,-83.703 L-2.961,-85.191 L-0.558,-87.089 L-3.284,-90.542 L-2.709,-90.995 L0.587,-93.202 L1.86,-93.916 L4.013,-90.079 L6.049,-91.222 L8.696,-92.443 L6.851,-96.439 L7.648,-96.806 L11.37,-98.18 L12.634,-98.535 L13.827,-94.3 L16.213,-94.972 L18.929,-95.51 L18.076,-99.826 L19.08,-100.025 L23.019,-100.486 L26.852,-100.634 L26.852,-100.639 L26.893,-100.639 L26.893,-100.643 L26.993,-100.639 L27.092,-100.643 L27.092,-100.639 L27.132,-100.639 L27.132,-100.634 L30.967,-100.486 L32.994,-100.248 L32.482,-95.878 L34.224,-95.675 L37.656,-94.995 L38.511,-99.312 L38.801,-99.255 L42.621,-98.179 L44.4,-97.522 L42.877,-93.395 L44.658,-92.737 L47.702,-91.332 L49.545,-95.327 L49.947,-95.141 L53.407,-93.199 L54.862,-92.226 L52.414,-88.569 L54.114,-87.431 L56.632,-85.444 L59.358,-88.897 L59.82,-88.533 L62.733,-85.839 L63.823,-84.661 L60.591,-81.673 L62.08,-80.065 L63.978,-77.66 L67.432,-80.387 L67.885,-79.812 L70.093,-76.514 L70.807,-75.241 L66.97,-73.087 L68.113,-71.051 L69.336,-68.403 L73.331,-70.248 L73.698,-69.451 L75.073,-65.727 L75.428,-64.462 L71.193,-63.27 L71.865,-60.883 L72.403,-58.165 L76.719,-59.019 L76.918,-58.014 L77.38,-54.073 L77.528,-50.239 L77.532,-50.239 L77.532,-50.129 L77.537,-49.999 L77.532,-49.999 L77.532,-42.449 L73.132,-42.449 L73.132,-35.18 L77.532,-35.18 L77.532,-27.39 L73.132,-27.39 L73.132,-20.121 L77.532,-20.121 L77.532,-12.332 L73.132,-12.332 L73.132,-5.062 L77.532,-5.062 L77.532,2.727 L73.132,2.727 L73.132,9.997 L77.532,9.997 L77.532,17.786 L73.132,17.786 L73.132,25.055 L77.532,25.055 L77.532,32.845 L73.132,32.845 L73.132,40.114 L77.532,40.114 L77.532,47.904 L73.132,47.904 L73.132,55.173 L77.532,55.173 L77.532,62.963 L73.132,62.963 L73.132,70.232 L77.532,70.232 L77.532,78.421 L69.82,78.421 L69.82,74.021 L63.027,74.021 L63.027,78.421 L55.714,78.421 L55.714,74.021 L48.922,74.021 L48.922,78.421 L41.609,78.421 L41.609,74.021 L34.816,74.021 L34.816,78.421 L27.504,78.421 L27.504,74.021 L20.711,74.021 L20.711,78.421 L13.399,78.421 L13.399,74.021 L6.606,74.021 L6.606,78.421 L-0.707,78.421 L-0.707,74.021 L-7.499,74.021 L-7.499,78.421 L-14.812,78.421 L-14.812,74.021 L-21.605,74.021 L-21.605,78.421 L-28.917,78.421 L-28.917,74.021 L-35.71,74.021 L-35.71,78.421 L-43.023,78.421 L-43.023,74.021 L-49.815,74.021 L-49.815,78.421 L-57.528,78.421 L-57.528,70.992 L-53.128,70.992 L-53.128,64.483 L-57.528,64.483 L-57.528,57.454 L-53.128,57.454 L-53.128,50.944 L-57.528,50.944 L-57.528,43.915 L-53.128,43.915 L-53.128,37.406 L-57.528,37.406 L-57.528,30.377 L-53.128,30.377 L-53.128,23.867 L-57.528,23.867 L-57.528,16.838 L-53.128,16.838 L-53.128,10.329 L-57.528,10.329 L-57.528,3.3 L-53.128,3.3 L-53.128,-3.209 L-57.528,-3.209 L-57.528,-10.639 L-51.6,-10.639 L-51.6,-6.239 L-49.994,-6.239 ZM42.872,-44.639 L46.472,-44.639 L46.472,-47.096 L50.872,-47.096 L50.872,-53.693 L46.472,-53.693 L46.472,-60.81 L50.872,-60.81 L50.872,-67.407 L46.472,-67.407 L46.472,-74.524 L50.872,-74.524 L50.872,-81.122 L46.472,-81.122 L46.472,-83.579 L42.872,-83.579 L42.872,-87.979 L35.132,-87.979 L35.132,-83.579 L26.872,-83.579 L26.872,-87.979 L19.132,-87.979 L19.132,-83.579 L15.532,-83.579 L15.532,-81.122 L11.132,-81.122 L11.132,-74.524 L15.532,-74.524 L15.532,-67.407 L11.132,-67.407 L11.132,-60.81 L15.532,-60.81 L15.532,-53.693 L11.132,-53.693 L11.132,-47.096 L15.532,-47.096 L15.532,-44.639 L19.132,-44.639 L19.132,-40.239 L26.872,-40.239 L26.872,-44.639 L35.132,-44.639 L35.132,-40.239 L42.872,-40.239 ZM60.272,64.361 L62.472,64.361 L62.472,62.161 L66.872,62.161 L66.872,55.821 L62.472,55.821 L62.472,48.961 L66.872,48.961 L66.872,42.621 L62.472,42.621 L62.472,40.421 L60.272,40.421 L60.272,36.021 L53.932,36.021 L53.932,40.421 L47.072,40.421 L47.072,36.021 L40.732,36.021 L40.732,40.421 L38.532,40.421 L38.532,42.621 L34.132,42.621 L34.132,48.961 L38.532,48.961 L38.532,55.821 L34.132,55.821 L34.132,62.161 L38.532,62.161 L38.532,64.361 L40.732,64.361 L40.732,68.761 L47.072,68.761 L47.072,64.361 L53.932,64.361 L53.932,68.761 L60.272,68.761 ZM-21.728,64.361 L-19.528,64.361 L-19.528,62.161 L-15.128,62.161 L-15.128,55.821 L-19.528,55.821 L-19.528,48.961 L-15.128,48.961 L-15.128,42.621 L-19.528,42.621 L-19.528,40.421 L-21.728,40.421 L-21.728,36.021 L-28.068,36.021 L-28.068,40.421 L-34.928,40.421 L-34.928,36.021 L-41.268,36.021 L-41.268,40.421 L-43.468,40.421 L-43.468,42.621 L-47.868,42.621 L-47.868,48.961 L-43.468,48.961 L-43.468,55.821 L-47.868,55.821 L-47.868,62.161 L-43.468,62.161 L-43.468,64.361 L-41.268,64.361 L-41.268,68.761 L-34.928,68.761 L-34.928,64.361 L-28.068,64.361 L-28.068,68.761 L-21.728,68.761 Z" style="stroke:red; stroke-width:0.01; fill:none"/>
    <g transform="rotate(0 10.002222222222237 72.021) translate(10.002,72.021) scale(0.004,0.004)">
      <path d="M 68 909 L 627 909 M 197 299 L 640 299 L 197 299 M 54 -142 L 640 -142 L 640 740 L 54 740" transform="translate(0,-503)" class="instructions" vector-effect="non-scaling-stroke"/>
      <path d="M 640 -142 L 640 299 M 55 299 L 54 -142 L 55 299 M 640 740 L 640 299 L 54 299" transform="translate(812,-503)" class="instructions" vector-effect="non-scaling-stroke"/>
    </g>
    <g transform="rotate(-90 75.532 13.891333333333323) translate(75.532,13.891) scale(0.004,0.004)">
      <path d="M 68 909 L 627 909 M 197 299 L 640 299 L 197 299 M 54 -142 L 640 -142 L 640 740 L 54 740" transform="translate(0,-503)" class="instructions" vector-effect="non-scaling-stroke"/>
      <path d="M 640 740 L 640 -150 L 469 21" transform="translate(812,-503)" class="instructions" vector-effect="non-scaling-stroke"/>
    </g>
    <g transform="rotate(-135 49.41755555555552 -72.524) translate(49.418,-72.524) scale(0.004,0.004)">
      <path d="M 68 909 L 627 909 M 197 299 L 640 299 L 197 299 M 54 -142 L 640 -142 L 640 740 L 54 740" transform="translate(0,-503)" class="instructions" vector-effect="non-scaling-stroke"/>
      <path d="M 640 740 L 640 -150 L 469 21" transform="translate(812,-503)" class="instructions" vector-effect="non-scaling-stroke"/>
    </g>
    <g transform="rotate(135 1.9922222222222068 -75.11866666666667) translate(1.992,-75.119) scale(0.004,0.004)">
      <path d="M 68 909 L 627 909 M 197 299 L 640 299 L 197 299 M 54 -142 L 640 -142 L 640 740 L 54 740" transform="translate(0,-503)" class="instructions" vector-effect="non-scaling-stroke"/>
      <path d="M 640 740 L 640 -150 L 469 21" transform="translate(812,-503)" class="instructions" vector-effect="non-scaling-stroke"/>
    </g>
  </g>
</svg>
```
</p>
</details>

This is what it should look like (e.g. in Inkscape):
![image](https://user-images.githubusercontent.com/2040603/56721143-906cd780-6744-11e9-9efc-4a4c8a909e8c.png)

What VisiCut saw instead (all the numbers are jumbled up in the middle):
![image](https://user-images.githubusercontent.com/2040603/56721058-61eefc80-6744-11e9-9bb0-8f5b0a6dad4b.png)

VisiCut fixed:
![image](https://user-images.githubusercontent.com/2040603/56721101-7af7ad80-6744-11e9-9fb8-36a34b309275.png)