### PR TITLE
use new LibLaserCut interface: better spline interpolation for LTT laser

### DIFF
--- a/src/com/t_oster/visicut/VisicutModel.java
+++ b/src/com/t_oster/visicut/VisicutModel.java
@@ -763,7 +763,7 @@ public class VisicutModel
         }
         List<LaserProperty> props = propmap.get(pr);
         try {
-          pr.addToLaserJob(job, set, this.addFocusOffset(props, focusOffset));
+          pr.addToLaserJob(job, set, this.addFocusOffset(props, focusOffset), this.selectedLaserDevice.getLaserCutter());
         } catch (InterruptedException ex) {
           throw new RuntimeException("this must not happen");
         }

--- a/src/com/t_oster/visicut/model/LaserProfile.java
+++ b/src/com/t_oster/visicut/model/LaserProfile.java
@@ -18,6 +18,7 @@
  **/
 package com.t_oster.visicut.model;
 
+import com.t_oster.liblasercut.LaserCutter;
 import com.t_oster.liblasercut.LaserJob;
 import com.t_oster.liblasercut.LaserProperty;
 import com.t_oster.liblasercut.platform.Util;
@@ -134,7 +135,7 @@ public abstract class LaserProfile implements ImageListable, Cloneable
   
   public abstract void renderPreview(Graphics2D g, GraphicSet objects, MaterialProfile material, AffineTransform mm2px) throws InterruptedException;
 
-  public abstract void addToLaserJob(LaserJob job, GraphicSet objects, List<LaserProperty> laserProperties) throws InterruptedException;
+  public abstract void addToLaserJob(LaserJob job, GraphicSet objects, List<LaserProperty> laserProperties, LaserCutter cutter) throws InterruptedException;
 
   @Override
   public String toString()

--- a/src/com/t_oster/visicut/model/Raster3dProfile.java
+++ b/src/com/t_oster/visicut/model/Raster3dProfile.java
@@ -18,6 +18,7 @@
  **/
 package com.t_oster.visicut.model;
 
+import com.t_oster.liblasercut.LaserCutter;
 import com.t_oster.liblasercut.LaserJob;
 import com.t_oster.liblasercut.LaserProperty;
 import com.t_oster.liblasercut.ProgressListener;
@@ -186,7 +187,7 @@ public class Raster3dProfile extends LaserProfile
   }
 
   @Override
-  public void addToLaserJob(LaserJob job, GraphicSet set, List<LaserProperty> laserProperties)
+  public void addToLaserJob(LaserJob job, GraphicSet set, List<LaserProperty> laserProperties, LaserCutter cutter)
   {
     double factor = Util.dpi2dpmm(this.getDPI());
     AffineTransform mm2laserPx = AffineTransform.getScaleInstance(factor, factor);

--- a/src/com/t_oster/visicut/model/RasterProfile.java
+++ b/src/com/t_oster/visicut/model/RasterProfile.java
@@ -19,6 +19,7 @@
 package com.t_oster.visicut.model;
 
 import com.t_oster.liblasercut.BlackWhiteRaster;
+import com.t_oster.liblasercut.LaserCutter;
 import com.t_oster.liblasercut.LaserJob;
 import com.t_oster.liblasercut.LaserProperty;
 import com.t_oster.liblasercut.ProgressListener;
@@ -221,7 +222,7 @@ public class RasterProfile extends LaserProfile
   }
 
   @Override
-  public void addToLaserJob(LaserJob job, GraphicSet set, List<LaserProperty> laserProperties) throws InterruptedException
+  public void addToLaserJob(LaserJob job, GraphicSet set, List<LaserProperty> laserProperties, LaserCutter cutter) throws InterruptedException
   {
     double factor = Util.dpi2dpmm(this.getDPI());
     AffineTransform mm2laserPx = AffineTransform.getScaleInstance(factor, factor);

--- a/src/com/t_oster/visicut/model/VectorProfile.java
+++ b/src/com/t_oster/visicut/model/VectorProfile.java
@@ -18,6 +18,7 @@
  **/
 package com.t_oster.visicut.model;
 
+import com.t_oster.liblasercut.LaserCutter;
 import com.t_oster.liblasercut.LaserJob;
 import com.t_oster.liblasercut.LaserProperty;
 import com.t_oster.liblasercut.VectorPart;
@@ -254,7 +255,7 @@ public class VectorProfile extends LaserProfile
   }
 
   @Override
-  public void addToLaserJob(LaserJob job, GraphicSet objects, List<LaserProperty> laserProperties)
+  public void addToLaserJob(LaserJob job, GraphicSet objects, List<LaserProperty> laserProperties, LaserCutter cutter)
   {
     if (this.isUseOutline())
     {
@@ -301,7 +302,7 @@ public class VectorProfile extends LaserProfile
             sh = objects.getTransform().createTransformedShape(sh);
           }
           sh = mm2laserpx.createTransformedShape(sh);
-          conv.addShape(sh, part);
+          conv.addShape(sh, part, cutter);
         }
       }
     }


### PR DESCRIPTION
- update LibLaserCut
- uses the new interface introduced in https://github.com/t-oster/LibLaserCut/pull/113
