### PR TITLE
Replace the obsolete com.apple.eawt with java.awt.desktop APIs. This …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-  - openjdk8
+  - openjdk9
   - openjdk11
 
 before_install:

--- a/src/com/t_oster/visicut/gui/MainView.java
+++ b/src/com/t_oster/visicut/gui/MainView.java
@@ -22,11 +22,11 @@ package com.t_oster.visicut.gui;
 // It is loaded dynamically iff JavaFX is available:
 // import com.tur0kk.thingiverse.gui.ThingiverseLoginDialog;
 import com.tur0kk.thingiverse.gui.ThingiverseDialog;
-import com.apple.eawt.AppEvent.AboutEvent;
-import com.apple.eawt.AppEvent.OpenFilesEvent;
-import com.apple.eawt.AppEvent.PreferencesEvent;
-import com.apple.eawt.AppEvent.QuitEvent;
-import com.apple.eawt.QuitResponse;
+import java.awt.desktop.AboutEvent;
+import java.awt.desktop.OpenFilesEvent;
+import java.awt.desktop.PreferencesEvent;
+import java.awt.desktop.QuitEvent;
+import java.awt.desktop.QuitResponse;
 import com.frochr123.fabqr.FabQRFunctions;
 import com.frochr123.fabqr.gui.FabQRUploadDialog;
 import com.frochr123.gui.QRWebcamScanDialog;
@@ -312,9 +312,9 @@ public class MainView extends javax.swing.JFrame
 
     if (Helper.isMacOS())
     {
-      com.apple.eawt.Application macApplication = com.apple.eawt.Application.getApplication();
+      java.awt.Desktop macApplication = java.awt.Desktop.getDesktop();
       jmPreferences.setVisible(false);
-      macApplication.setPreferencesHandler(new com.apple.eawt.PreferencesHandler()
+      macApplication.setPreferencesHandler(new java.awt.desktop.PreferencesHandler()
       {
 
         public void handlePreferences(PreferencesEvent pe)
@@ -323,7 +323,7 @@ public class MainView extends javax.swing.JFrame
         }
       });
       exitMenuItem.setVisible(false);
-      macApplication.setQuitHandler(new com.apple.eawt.QuitHandler()
+      macApplication.setQuitHandler(new java.awt.desktop.QuitHandler()
       {
 
         public void handleQuitRequestWith(QuitEvent qe, QuitResponse qr)
@@ -332,7 +332,7 @@ public class MainView extends javax.swing.JFrame
         }
       });
       aboutMenuItem.setVisible(false);
-      macApplication.setAboutHandler(new com.apple.eawt.AboutHandler()
+      macApplication.setAboutHandler(new java.awt.desktop.AboutHandler()
       {
 
         public void handleAbout(AboutEvent ae)
@@ -340,7 +340,7 @@ public class MainView extends javax.swing.JFrame
           MainView.this.aboutMenuItemActionPerformed(null);
         }
       });
-      macApplication.setOpenFileHandler(new com.apple.eawt.OpenFilesHandler()
+      macApplication.setOpenFileHandler(new java.awt.desktop.OpenFilesHandler()
       {
 
         public void openFiles(OpenFilesEvent ofe)


### PR DESCRIPTION
…is required to run visicut on macs that have java > 8. And update travis CI config to swap jkd8 with jdk9.

See: http://openjdk.java.net/jeps/272 and https://docs.oracle.com/javase/9/migrate/toc.htm#JSMIG-GUID-C86F7403-7D7C-456F-8873-18C7F1BEDE2F