### PR TITLE
remove outdated info in linux description

### DIFF
--- a/distribute/linux/description-pak
+++ b/distribute/linux/description-pak
@@ -1,3 +1,3 @@
 VisiCut is a userfriendly tool for creating, saving and sending jobs to lasercutters.
-Currently the Epilog ZING, Epilog Helix and LAOS Open Source Laser (www.laoslaser.org) Lasercutters are supported, but other drivers will be implemented soon.
+Currently the Epilog ZING, Epilog Helix and LAOS Open Source Laser (www.laoslaser.org) Lasercutters are supported.
 For more information see http://visicut.org


### PR DESCRIPTION
file was not modified since 2015 - see https://github.com/t-oster/VisiCut/commits/d0e9d529af2fc56e9f73c19f393ecc8feaf0c5ed/distribute/linux/description-pak so "soon" is rather misleading

Though maybe instead more supported devices should be listed instead.

BTW, is this software going to support ATMSolutions C02 PRO35 MINI connected via USB? Probably not, but if yes - then amending the description would be likely a good idea.