### PR TITLE
Fix gui threadsafety

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 # Temporary files:
 /distribute/wintmp/
 *~
+*.orig
 
 # Maven stuff:
 /lib/nbproject/private/

--- a/src/com/t_oster/visicut/gui/ThreadUtils.java
+++ b/src/com/t_oster/visicut/gui/ThreadUtils.java
@@ -1,0 +1,76 @@
+/**
+ * This file is part of VisiCut.
+ * Copyright (C) 2011 - 2013 Thomas Oster <thomas.oster@rwth-aachen.de>
+ * RWTH Aachen University - 52062 Aachen, Germany
+ *
+ *     VisiCut is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Lesser General Public License as published by
+ *     the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     VisiCut is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Lesser General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Lesser General Public License
+ *     along with VisiCut.  If not, see <http://www.gnu.org/licenses/>.
+ **/
+package com.t_oster.visicut.gui;
+
+import java.lang.reflect.InvocationTargetException;
+import javax.swing.SwingUtilities;
+
+/**
+ * Utilities for thread safety in the GUI context.
+ *
+ * Suggested reading:
+ * https://docs.oracle.com/javase/tutorial/uiswing/concurrency/index.html
+ *
+ * @author Max Gaukler <development@maxgaukler.de>
+ */
+public class ThreadUtils
+{
+  /**
+   * Runs the given method in the GUI (AWT Event Dispatcher Thread) context.
+   * This must be used if the GUI elements are accessed from other threads.
+   * This function is a wrapper for SwingUtilities.invokeAndWait.
+   *
+   * Example usage:
+   * ThreadUtils.runIn
+   *
+   * @param r lambda expression or Runnable
+   */
+  public static void runInGUIThread(Runnable r) {
+    if (SwingUtilities.isEventDispatchThread()) {
+      r.run();
+    } else {
+      try
+      {
+        SwingUtilities.invokeAndWait(r);
+      }
+      catch (InterruptedException ex)
+      {
+        Thread.getDefaultUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), ex);
+      }
+      catch (InvocationTargetException ex)
+      {
+        // uncaught exception inside the runnable
+        Thread.getDefaultUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), ex.getCause());
+      }
+    }
+  }
+
+  /**
+   * warn if we are not in the GUI thread
+   */
+  public static void assertInGUIThread() {
+    try {
+      if (!SwingUtilities.isEventDispatchThread()) {
+        throw new Exception("Warning: A GUI function was called from the non-GUI thread " + Thread.currentThread().getName() + ". This may cause sporadic errors and should therefore be fixed.");
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/main/java/com/frochr123/periodictasks/RefreshCameraThread.java
+++ b/src/main/java/com/frochr123/periodictasks/RefreshCameraThread.java
@@ -34,7 +34,7 @@ public class RefreshCameraThread extends Thread
   // Constructor
   public RefreshCameraThread()
   {
-    super();
+    super("RefreshCameraThread");
   }
 
   // Compute update timer, ensure valid data

--- a/src/main/java/com/frochr123/qrcodescan/QRCodeScannerThread.java
+++ b/src/main/java/com/frochr123/qrcodescan/QRCodeScannerThread.java
@@ -54,7 +54,7 @@ public class QRCodeScannerThread extends Thread
   // Constructor, needs QRCodeScanner
   public QRCodeScannerThread(QRCodeScanner scanner)
   {
-    super();
+    super("QRCodeScannerThread");
     this.scanner = scanner;
     active = false;
   }

--- a/src/main/java/de/thomas_oster/uicomponents/warnings/WarningPanel.java
+++ b/src/main/java/de/thomas_oster/uicomponents/warnings/WarningPanel.java
@@ -19,6 +19,7 @@
 package de.thomas_oster.uicomponents.warnings;
 
 import de.thomas_oster.visicut.gui.MainView;
+import com.t_oster.visicut.gui.ThreadUtils;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.HashMap;
@@ -62,6 +63,7 @@ public class WarningPanel extends javax.swing.JPanel
   
   public void addMessage(final Message m)
   {
+    ThreadUtils.assertInGUIThread();
     messages.add(m);
     m.setCloseListener(new ActionListener(){
       public void actionPerformed(ActionEvent ae)
@@ -80,6 +82,7 @@ public class WarningPanel extends javax.swing.JPanel
   }
   
   public void removeMessage(final Message m, boolean hidePanelIfEmpty) {
+    ThreadUtils.assertInGUIThread();
     messagesById.values().remove(m);
     messages.remove(m);
     warningContainer.remove(m);
@@ -109,6 +112,7 @@ public class WarningPanel extends javax.swing.JPanel
    */
   public WarningPanel()
   {
+    ThreadUtils.assertInGUIThread();
     initComponents();
   }
 

--- a/src/main/java/de/thomas_oster/uicomponents/warnings/WarningPanel.java
+++ b/src/main/java/de/thomas_oster/uicomponents/warnings/WarningPanel.java
@@ -41,11 +41,13 @@ public class WarningPanel extends javax.swing.JPanel
   
   public void removeAllWarnings()
   {
-    // removeMessage calls messages.remove(), so we can't use foreach here!
-    while (messages.size() > 0)
-    {
-      removeMessage(messages.get(0));
-    }
+    ThreadUtils.runInGUIThread(()->{
+        // removeMessage calls messages.remove(), so we can't use foreach here!
+        while (messages.size() > 0)
+        {
+          removeMessage(messages.get(0));
+        }
+    });
   }
   
   /**
@@ -54,27 +56,30 @@ public class WarningPanel extends javax.swing.JPanel
    * @param messageId unique message identifier like 'camera error'. If null, no old message will be removed.
    */
   public void addMessageOnce(final Message newMessage, String messageId) {
-    addMessage(newMessage);
-    if (messageId != null) {
-      removeMessageWithId(messageId, false);
-      messagesById.put(messageId, newMessage);
-    }
+    ThreadUtils.runInGUIThread(()->{
+        addMessage(newMessage);
+        if (messageId != null) {
+          removeMessageWithId(messageId, false);
+          messagesById.put(messageId, newMessage);
+        }
+    });
   }
   
   public void addMessage(final Message m)
   {
-    ThreadUtils.assertInGUIThread();
-    messages.add(m);
-    m.setCloseListener(new ActionListener(){
-      public void actionPerformed(ActionEvent ae)
-      {
-        removeMessage(m);
-      }
+    ThreadUtils.runInGUIThread(()->{
+        messages.add(m);
+        m.setCloseListener(new ActionListener(){
+          public void actionPerformed(ActionEvent ae)
+          {
+            removeMessage(m);
+          }
+        });
+        this.warningContainer.add(m);
+        revalidate();
+        repaint();
+        setVisible(true);
     });
-    this.warningContainer.add(m);
-    revalidate();
-    repaint();
-    setVisible(true);
   }
   
   public void removeMessage(final Message m) {
@@ -82,25 +87,28 @@ public class WarningPanel extends javax.swing.JPanel
   }
   
   public void removeMessage(final Message m, boolean hidePanelIfEmpty) {
-    ThreadUtils.assertInGUIThread();
-    messagesById.values().remove(m);
-    messages.remove(m);
-    warningContainer.remove(m);
-    m.setCloseListener(null);
-    
-    revalidate();
-    repaint();
+    ThreadUtils.runInGUIThread(()->{
+        messagesById.values().remove(m);
+        messages.remove(m);
+        warningContainer.remove(m);
+        m.setCloseListener(null);
 
-    if (messages.isEmpty() && hidePanelIfEmpty)
-    {
-      setVisible(false);
-    }
+        revalidate();
+        repaint();
+
+        if (messages.isEmpty() && hidePanelIfEmpty)
+        {
+          setVisible(false);
+        }
+    });
   }
   
   public void removeMessageWithId(String messageId, boolean hidePanelIfEmpty) {
-    if (messagesById.containsKey(messageId)) {
-      removeMessage(messagesById.get(messageId), hidePanelIfEmpty);
-    }
+    ThreadUtils.runInGUIThread(()->{
+        if (messagesById.containsKey(messageId)) {
+          removeMessage(messagesById.get(messageId), hidePanelIfEmpty);
+        }
+    });
   }
   
   public void removeMessageWithId(String messageId) {

--- a/src/main/java/de/thomas_oster/uicomponents/warnings/WarningPanel.java
+++ b/src/main/java/de/thomas_oster/uicomponents/warnings/WarningPanel.java
@@ -19,7 +19,7 @@
 package de.thomas_oster.uicomponents.warnings;
 
 import de.thomas_oster.visicut.gui.MainView;
-import com.t_oster.visicut.gui.ThreadUtils;
+import de.thomas_oster.visicut.gui.ThreadUtils;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.HashMap;

--- a/src/main/java/de/thomas_oster/visicut/gui/MainView.java
+++ b/src/main/java/de/thomas_oster/visicut/gui/MainView.java
@@ -1866,6 +1866,13 @@ public class MainView extends javax.swing.JFrame
 
     try
     {
+      while (true) {
+        if (false) {
+          break; // never reached, but gets rid of "unreachable code" warnings
+        }
+        this.progressBar.setIndeterminate(true);
+        this.progressBar.setIndeterminate(false);
+      }
       this.progressBar.setIndeterminate(true);
       LinkedList<String> warnings = new LinkedList<String>();
       this.visicutModel1.loadFile(MappingManager.getInstance(), file, warnings, discardCurrent);

--- a/src/main/java/de/thomas_oster/visicut/gui/MainView.java
+++ b/src/main/java/de/thomas_oster/visicut/gui/MainView.java
@@ -487,6 +487,7 @@ public class MainView extends javax.swing.JFrame
 
   private void refreshExampleMenu()
   {
+    ThreadUtils.assertInGUIThread();
     jmExamples.removeAll();
     JMenu builtin = new JMenu(bundle.getString("BUILTIN"));
     this.fillMenu(builtin, PreferencesManager.getInstance().getBuiltinExampleFiles());
@@ -514,6 +515,7 @@ public class MainView extends javax.swing.JFrame
    */
   private void refreshRecentFilesMenu()
   {
+    ThreadUtils.assertInGUIThread();
     this.recentFilesMenu.removeAll();
     for (String p : this.visicutModel1.getPreferences().getRecentFiles())
     {
@@ -536,6 +538,7 @@ public class MainView extends javax.swing.JFrame
 
   private void refreshMaterialComboBox()
   {
+    ThreadUtils.assertInGUIThread();
     this.ignoreMaterialComboBoxChanges = true;
     String sp = this.visicutModel1.getMaterial() != null ? this.visicutModel1.getMaterial().getName() : null;
     this.materialComboBox.removeAllItems();
@@ -600,6 +603,7 @@ public class MainView extends javax.swing.JFrame
 
   private void refreshLaserDeviceComboBox()
   {
+    ThreadUtils.assertInGUIThread();
     String sld = this.visicutModel1.getSelectedLaserDevice() != null ? this.visicutModel1.getSelectedLaserDevice().getName() : null;
     ignoreLaserCutterComboBoxUpdates = true;
     this.laserCutterComboBox.removeAllItems();
@@ -633,6 +637,7 @@ public class MainView extends javax.swing.JFrame
    */
   public void refreshObjectComboBox()
   {
+    ThreadUtils.assertInGUIThread();
     this.ignoreObjectComboBoxEvents = true;
     // fill new list of PlfItems
     this.objectComboBox.removeAllItems();
@@ -1745,6 +1750,7 @@ public class MainView extends javax.swing.JFrame
   }// </editor-fold>//GEN-END:initComponents
 
     private void exitMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_exitMenuItemActionPerformed
+      ThreadUtils.assertInGUIThread();
       Rectangle bounds = this.getBounds();
       if ((this.getExtendedState() & MAXIMIZED_BOTH) == MAXIMIZED_BOTH) {
         // window is maximized, store this as "null"
@@ -1855,41 +1861,53 @@ public class MainView extends javax.swing.JFrame
       }));
   }
 
+  /**
+   * Load file.
+   * This method is safe to call also from non-GUI-Threads.
+   * @param file
+   * @param discardCurrent true: replace old file
+   */
   private void loadFileReal(File file, boolean discardCurrent)
   {
-    // bring window to front - needed when VisiCut was called from a plugin
-    this.toFront();
-    this.requestFocus();
+    ThreadUtils.runInGUIThread(()->{
+      // we would like to call: this.setEnabled(false); // ignore user events (mouse, keyboard)
+      // but it causes flicker, so don't do it for now.
+      this.progressBar.setIndeterminate(true);
+      // bring window to front - needed when VisiCut was called from a plugin
+      this.toFront();
+      this.requestFocus();
 
-    // remove old error messages, they are no longer relevant (or for multiple files it is too confusing which one refers to which file)
-    warningPanel.removeAllWarnings();
+      // remove old error messages, they are no longer relevant (or for multiple files it is too confusing which one refers to which file)
+      warningPanel.removeAllWarnings();
+    });
 
     try
     {
-      while (true) {
-        if (false) {
-          break; // never reached, but gets rid of "unreachable code" warnings
-        }
-        this.progressBar.setIndeterminate(true);
-        this.progressBar.setIndeterminate(false);
-      }
-      this.progressBar.setIndeterminate(true);
       LinkedList<String> warnings = new LinkedList<String>();
       this.visicutModel1.loadFile(MappingManager.getInstance(), file, warnings, discardCurrent);
-      if (!warnings.isEmpty())
-      {
-        dialog.showWarningMessage(warnings);
-      }
-      //if the image is too big, fit it a nd notify the user
-      this.fitObjectsIntoBed();
-      this.progressBar.setIndeterminate(false);
-      this.refreshButtonStates(VisicutModel.PROP_PLF_PART_ADDED);
+      ThreadUtils.runInGUIThread(()->{
+        if (!warnings.isEmpty())
+        {
+          dialog.showWarningMessage(warnings);
+        }
+        //if the image is too big, fit it and notify the user
+        this.fitObjectsIntoBed();
+        this.progressBar.setIndeterminate(false);
+        this.refreshButtonStates(VisicutModel.PROP_PLF_PART_ADDED);
+      });
+
     }
     catch (Exception e)
     {
-      this.progressBar.setIndeterminate(false);
-      dialog.showErrorMessage(e, bundle.getString("ERROR WHILE OPENING '") + file.getName() + "'");
+      ThreadUtils.runInGUIThread(()->{
+        dialog.showErrorMessage(e, bundle.getString("ERROR WHILE OPENING '") + file.getName() + "'");
+      });
     }
+
+    ThreadUtils.runInGUIThread(()->{
+      this.progressBar.setIndeterminate(false);
+      // this.setEnabled(true);
+    });
   }
 
   /**
@@ -1897,6 +1915,7 @@ public class MainView extends javax.swing.JFrame
    */
   public void refreshButtonStates(String action)
   {
+    ThreadUtils.assertInGUIThread();
     // Is called at application start up as well
     if (action != null && action.equals(VisicutModel.PROP_SELECTEDLASERDEVICE))
     {
@@ -1966,6 +1985,7 @@ public class MainView extends javax.swing.JFrame
 
   public void refreshExecuteButtons(boolean skipLockCheck)
   {
+    ThreadUtils.assertInGUIThread();
     boolean execute = this.visicutModel1.getMaterial() != null
       && this.visicutModel1.getSelectedLaserDevice() != null
       && this.visicutModel1.getPlfFile().size() > 0
@@ -2046,6 +2066,7 @@ private void openMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
 
   private void editMappings() throws FileNotFoundException, IOException
   {
+    ThreadUtils.assertInGUIThread();
     List<MappingSet> mappingsets = new LinkedList<MappingSet>();
     for (MappingSet m : MappingManager.getInstance().getAll())
     {
@@ -2079,12 +2100,14 @@ private void openMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
 
       public void progressChanged(Object o, int i)
       {
+        ThreadUtils.assertInGUIThread();
         MainView.this.progressBar.setValue(i);
         MainView.this.progressBar.repaint();
       }
 
       public void taskChanged(Object o, String string)
       {
+        ThreadUtils.assertInGUIThread();
         MainView.this.progressBar.setString(string);
       }
     };
@@ -2105,6 +2128,7 @@ private void openMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-
 
   private String getJobName()
   {
+    ThreadUtils.assertInGUIThread();
     String jobname = "(unnamed job)";
     try
     {
@@ -2228,15 +2252,18 @@ private void aboutMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN
 
             public void progressChanged(Object o, int i)
             {
+              ThreadUtils.assertInGUIThread(); // FIXME: this causes warnings, and they are right
               MainView.this.progressBar.setValue(i);
               MainView.this.progressBar.repaint();
             }
 
             public void taskChanged(Object o, String string)
             {
+              ThreadUtils.assertInGUIThread(); // FIXME: this causes warnings, and they are right
               MainView.this.progressBar.setString(string);
             }
           };
+          ThreadUtils.assertInGUIThread(); // FIXME: this causes warnings, and they are right
           MainView.this.progressBar.setMinimum(0);
           MainView.this.progressBar.setMaximum(100);
           MainView.this.progressBar.setValue(1);
@@ -2396,82 +2423,85 @@ private void saveAsMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GE
 }//GEN-LAST:event_saveAsMenuItemActionPerformed
 
 private void visicutModel1PropertyChange(java.beans.PropertyChangeEvent evt) {//GEN-FIRST:event_visicutModel1PropertyChange
-  if (evt.getPropertyName().equals(VisicutModel.PROP_PLF_PART_ADDED)
-    || evt.getPropertyName().equals(VisicutModel.PROP_PLF_PART_REMOVED)
-    || evt.getPropertyName().equals(VisicutModel.PROP_SELECTEDPART))
-  {
-    // regenerate list of parts, update selection in ComboBox
-    this.refreshObjectComboBox();
-  }
+  ThreadUtils.runInGUIThread(() -> { // FIXME: THis should not be required, something is wrong with the way we set up PropertyChangeListener.
+    if (evt.getPropertyName().equals(VisicutModel.PROP_PLF_PART_ADDED)
+      || evt.getPropertyName().equals(VisicutModel.PROP_PLF_PART_REMOVED)
+      || evt.getPropertyName().equals(VisicutModel.PROP_SELECTEDPART))
+    {
+      // regenerate list of parts, update selection in ComboBox
+      this.refreshObjectComboBox();
+      this.refreshButtonStates(evt.getPropertyName());
+    }
 
-  if (evt.getPropertyName().equals(VisicutModel.PROP_PLF_FILE_CHANGED))
-  {
-    MainView.this.timeLabel.setText("");
-    if (this.visicutModel1.getPlfFile().getFile() != null)
+    if (evt.getPropertyName().equals(VisicutModel.PROP_PLF_FILE_CHANGED))
     {
-      this.setTitle("VisiCut - " + this.visicutModel1.getPlfFile().getFile().getName());
-    }
-    else
-    {
-      this.setTitle("VisiCut - Unnamed PLF");
-    }
-    this.refreshButtonStates(evt.getPropertyName());
-  }
-  else if (evt.getPropertyName().equals(VisicutModel.PROP_SELECTEDLASERDEVICE)
-    || evt.getPropertyName().equals(VisicutModel.PROP_PLF_PART_UPDATED)
-    || evt.getPropertyName().equals(VisicutModel.PROP_PLF_PART_REMOVED))
-  {
-    MainView.this.timeLabel.setText("");
-    this.refreshButtonStates(evt.getPropertyName());
-  }
-  else if (evt.getPropertyName().equals(VisicutModel.PROP_SELECTEDPART))
-  {
-    PlfPart p = this.visicutModel1.getSelectedPart();
-    this.mappingTabbedPane.setVisible(p != null);
-    if (p != null)
-    {
-      if (p instanceof ParametricPlfPart)
+      MainView.this.timeLabel.setText("");
+      if (this.visicutModel1.getPlfFile().getFile() != null)
       {
-        if (this.mappingTabbedPane.indexOfTabComponent(this.parameterPanel) == -1)
-        {
-          this.mappingTabbedPane.add(bundle.getString("PARAMETERS"), this.parameterPanel);
-        }
+        this.setTitle("VisiCut - " + this.visicutModel1.getPlfFile().getFile().getName());
       }
       else
       {
-        if (this.mappingTabbedPane.indexOfTabComponent(this.parameterPanel) == -1)
+        this.setTitle("VisiCut - Unnamed PLF");
+      }
+      this.refreshButtonStates(evt.getPropertyName());
+    }
+    else if (evt.getPropertyName().equals(VisicutModel.PROP_SELECTEDLASERDEVICE)
+      || evt.getPropertyName().equals(VisicutModel.PROP_PLF_PART_UPDATED)
+      || evt.getPropertyName().equals(VisicutModel.PROP_PLF_PART_REMOVED))
+    {
+      MainView.this.timeLabel.setText("");
+      this.refreshButtonStates(evt.getPropertyName());
+    }
+    else if (evt.getPropertyName().equals(VisicutModel.PROP_SELECTEDPART))
+    {
+      PlfPart p = this.visicutModel1.getSelectedPart();
+      this.mappingTabbedPane.setVisible(p != null);
+      if (p != null)
+      {
+        if (p instanceof ParametricPlfPart)
         {
-          this.mappingTabbedPane.remove(this.parameterPanel);
+          if (this.mappingTabbedPane.indexOfTabComponent(this.parameterPanel) == -1)
+          {
+            this.mappingTabbedPane.add(bundle.getString("PARAMETERS"), this.parameterPanel);
+          }
+        }
+        else
+        {
+          if (this.mappingTabbedPane.indexOfTabComponent(this.parameterPanel) == -1)
+          {
+            this.mappingTabbedPane.remove(this.parameterPanel);
+          }
         }
       }
     }
-  }
-  else if (evt.getPropertyName().equals(VisicutModel.PROP_MATERIAL))
-  {
-    MainView.this.timeLabel.setText("");
-    this.refreshMaterialThicknessesComboBox();
-    this.refreshButtonStates(evt.getPropertyName());
-  }
-  // Called on application start (= loading preferences) and change preferences
-  else if (evt.getPropertyName().equals(VisicutModel.PROP_PREFERENCES))
-  {
-    Preferences p = null;
+    else if (evt.getPropertyName().equals(VisicutModel.PROP_MATERIAL))
+    {
+      MainView.this.timeLabel.setText("");
+      this.refreshMaterialThicknessesComboBox();
+      this.refreshButtonStates(evt.getPropertyName());
+    }
+    // Called on application start (= loading preferences) and change preferences
+    else if (evt.getPropertyName().equals(VisicutModel.PROP_PREFERENCES))
+    {
+      Preferences p = null;
 
-    if (evt.getNewValue() != null)
-    {
-      p = (Preferences) (evt.getNewValue());
-    }
-    else if (PreferencesManager.getInstance() != null && PreferencesManager.getInstance().getPreferences() != null)
-    {
-      p = PreferencesManager.getInstance().getPreferences();
-    }
+      if (evt.getNewValue() != null)
+      {
+        p = (Preferences) (evt.getNewValue());
+      }
+      else if (PreferencesManager.getInstance() != null && PreferencesManager.getInstance().getPreferences() != null)
+      {
+        p = PreferencesManager.getInstance().getPreferences();
+      }
 
-    if (p != null)
-    {
-      btQRWebcamScan.setVisible(p.isEnableQRCodes());
-      webcamQRCodeMenuItem.setVisible(p.isEnableQRCodes());
+      if (p != null)
+      {
+        btQRWebcamScan.setVisible(p.isEnableQRCodes());
+        webcamQRCodeMenuItem.setVisible(p.isEnableQRCodes());
+      }
     }
-  }
+  });
 }//GEN-LAST:event_visicutModel1PropertyChange
 
 private void saveMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_saveMenuItemActionPerformed
@@ -2498,6 +2528,7 @@ private void newMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-F
 }//GEN-LAST:event_newMenuItemActionPerformed
 
 private void calibrateCameraMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_calibrateCameraMenuItemActionPerformed
+  ThreadUtils.assertInGUIThread();
   List<VectorProfile> profiles = ProfileManager.getInstance().getVectorProfiles();
   if (profiles.isEmpty())
   {
@@ -2730,6 +2761,7 @@ private void materialComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//
 
   private void materialMenuItemActionPerformed(java.awt.event.ActionEvent evt)//GEN-FIRST:event_materialMenuItemActionPerformed
   {//GEN-HEADEREND:event_materialMenuItemActionPerformed
+    ThreadUtils.assertInGUIThread();
     EditMaterialsDialog d = new EditMaterialsDialog(this, true);
     d.setMaterials(MaterialManager.getInstance().getAll());
     d.setVisible(true);
@@ -2753,6 +2785,7 @@ private void materialComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//
 
   private void laserCutterComboBoxActionPerformed(java.awt.event.ActionEvent evt)//GEN-FIRST:event_laserCutterComboBoxActionPerformed
   {//GEN-HEADEREND:event_laserCutterComboBoxActionPerformed
+    ThreadUtils.assertInGUIThread();
     if (!ignoreLaserCutterComboBoxUpdates)
     {
       LaserDevice newDev = laserCutterComboBox.getSelectedItem() instanceof LaserDevice ? (LaserDevice) laserCutterComboBox.getSelectedItem() : null;
@@ -2774,6 +2807,7 @@ private void materialComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//
 
   private void jMenuItem2ActionPerformed(java.awt.event.ActionEvent evt)//GEN-FIRST:event_jMenuItem2ActionPerformed
   {//GEN-HEADEREND:event_jMenuItem2ActionPerformed
+    ThreadUtils.assertInGUIThread();
     ManageLasercuttersDialog d = new ManageLasercuttersDialog(this, true);
     d.setLaserCutters(LaserDeviceManager.getInstance().getAll());
     d.setVisible(true);
@@ -2814,24 +2848,32 @@ private void materialComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//
 
   private void calculateTimeButtonActionPerformed(java.awt.event.ActionEvent evt)//GEN-FIRST:event_calculateTimeButtonActionPerformed
   {//GEN-HEADEREND:event_calculateTimeButtonActionPerformed
+    ThreadUtils.assertInGUIThread();
+    MainView.this.calculateTimeButton.setEnabled(false);
+    MainView.this.timeLabel.setText("...");
     new Thread()
     {
-
       @Override
       public void run()
       {
+        this.setName("calculateTimeThread");
         try
         {
-          MainView.this.calculateTimeButton.setEnabled(false);
-          MainView.this.timeLabel.setText("...");
-          MainView.this.timeLabel.setText(Helper.toHHMMSS(MainView.this.visicutModel1.estimateTime(MainView.this.getPropertyMapForCurrentJob())));
-          MainView.this.calculateTimeButton.setEnabled(true);
+          String result = Helper.toHHMMSS(MainView.this.visicutModel1.estimateTime(MainView.this.getPropertyMapForCurrentJob()));
+          ThreadUtils.runInGUIThread(() ->
+          {
+            MainView.this.timeLabel.setText(result);
+            MainView.this.calculateTimeButton.setEnabled(true);
+          });
         }
         catch (Exception ex)
         {
-          dialog.showErrorMessage(ex);
-          MainView.this.timeLabel.setText("error");
-          MainView.this.calculateTimeButton.setEnabled(true);
+          ThreadUtils.runInGUIThread(() ->
+          {
+            dialog.showErrorMessage(ex);
+            MainView.this.timeLabel.setText("error");
+            MainView.this.calculateTimeButton.setEnabled(true);
+          });
         }
       }
     }.start();
@@ -2916,6 +2958,7 @@ private void materialComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//
    */
   private void importSettingsFromFile(File file) throws Exception
   {
+    ThreadUtils.assertInGUIThread();
     PreferencesManager.getInstance().importSettings(file);
     this.visicutModel1.setPreferences(PreferencesManager.getInstance().getPreferences());
     // unset the lab name for auto-updates. Will be reset in importSettingsFromWeb,
@@ -3022,6 +3065,7 @@ private void materialComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//
 
   private void jmManageLaserprofilesActionPerformed(java.awt.event.ActionEvent evt)//GEN-FIRST:event_jmManageLaserprofilesActionPerformed
   {//GEN-HEADEREND:event_jmManageLaserprofilesActionPerformed
+    ThreadUtils.assertInGUIThread();
     EditProfilesDialog d = new EditProfilesDialog(this, true);
     List<LaserProfile> profiles = new LinkedList<LaserProfile>();
     profiles.addAll(ProfileManager.getInstance().getAll());
@@ -3044,6 +3088,7 @@ private void materialComboBoxActionPerformed(java.awt.event.ActionEvent evt) {//
 
   private void btAddMaterialActionPerformed(java.awt.event.ActionEvent evt)//GEN-FIRST:event_btAddMaterialActionPerformed
   {//GEN-HEADEREND:event_btAddMaterialActionPerformed
+    ThreadUtils.assertInGUIThread();
     CreateNewMaterialDialog cd = new CreateNewMaterialDialog(this, true);
     cd.setVisible(true);
     if (!cd.isOkClicked())
@@ -3728,6 +3773,7 @@ private void projectorActiveMenuItemActionPerformed(java.awt.event.ActionEvent e
 
   private void refreshMaterialThicknessesComboBox()
   {
+    ThreadUtils.assertInGUIThread();
     if (VisicutModel.getInstance().getMaterial() != null)
     {
       Float current = (Float) this.cbMaterialThickness.getSelectedItem();

--- a/src/main/java/de/thomas_oster/visicut/gui/ThreadUtils.java
+++ b/src/main/java/de/thomas_oster/visicut/gui/ThreadUtils.java
@@ -16,7 +16,7 @@
  *     You should have received a copy of the GNU Lesser General Public License
  *     along with VisiCut.  If not, see <http://www.gnu.org/licenses/>.
  **/
-package com.t_oster.visicut.gui;
+package de.thomas_oster.visicut.gui;
 
 import java.lang.reflect.InvocationTargetException;
 import javax.swing.SwingUtilities;


### PR DESCRIPTION
This diagnoses and hopefully mostly fixes #538 . 

The crashes have a really low probability under Linux, but can be provoked by https://github.com/t-oster/VisiCut/commit/1c0b26bc78d65e9e511c41c1315daa76e9d9c3d0 .

In summary, we must never call GUI functions, e.g. `progressBar.setProgress()`, from any thread exept the Event Dispatcher Thread. This means that if we create a new thread, all GUI operations need to be encapsulated with `SwingUtilities.invokeAndWait` (or `invokeLater`). I wrote wrapper functions (ThreadUtils class) to make that easier: `assertInGUIThread` prints a warning if you are not in the right thread, and `runInGUIThread(()->{ progressBar.setProgress(42); });` calls `progressBar.setProgress(42);` in the GUI context (blocking until it finishes). The "weird syntax" `()->{...}` is a lambda expression; you can also use anonymous inner classes (subclass of Runnable as for Threads).