### PR TITLE
Linux/Mac: Print and check Java version

### DIFF
--- a/distribute/files/VisiCut.Linux
+++ b/distribute/files/VisiCut.Linux
@@ -2,9 +2,15 @@
 # VisiCut Linux Starter
 script="`readlink -f "${BASH_SOURCE[0]}"`"
 DIR="`dirname "$script"`"
+
+# Print and check java version
+java -version 2>&1 | tee /dev/stderr | egrep -q '"[1-9][0-9]\..*"' || echo "Warning: Your Java version may be too old. We recommend Java 11 or newer. Trying anyway."
+
 # get the number-part of the display variable
 port=${DISPLAY##*:}
 port=${port%.*}
 # add it to the instance-port
 let port=port+6543
-java -Xms256m -Xmx2048m -jar "$DIR/Visicut.jar" --singleinstanceport $port "$@"
+
+# start VisiCut (assuming the system has at least 3GB RAM)
+exec java -Xms256m -Xmx2048m -jar "$DIR/Visicut.jar" --singleinstanceport $port "$@"

--- a/distribute/files/VisiCut.MacOS
+++ b/distribute/files/VisiCut.MacOS
@@ -1,3 +1,7 @@
 #!/bin/bash
 DIR="$( cd -P "$( dirname "$0" )" && pwd )"
+
+# Print and check java version
+java -version 2>&1 | tee /dev/stderr | egrep -q '"[1-9][0-9]\..*"' || echo "Warning: Your Java version may be too old. We recommend Java 11 or newer. Trying anyway."
+
 java -Xms256m -Xmx2048m -jar "$DIR/Visicut.jar" --singleinstanceport 6543 "$@"


### PR DESCRIPTION
Show a warning if the Java version is below 10.

This needs to be tested on Mac before merging -- I don't have one.