### PR TITLE
Split settings into public and private part

### DIFF
--- a/src/main/java/de/thomas_oster/visicut/Preferences.java
+++ b/src/main/java/de/thomas_oster/visicut/Preferences.java
@@ -33,6 +33,19 @@ public class Preferences
   {
   }
   
+  /**
+   * Clear all preferences which are user-specific, e.g., recent files and window-size
+   */
+  public void anonymize()
+  {
+    setLastMaterial(null);
+    setLastLaserDevice(null);
+    setRecentFiles(null);
+    setWindowBounds(null);
+    lastAutoUpdateTime=0;
+    setLastAutoUpdateLabName(null);
+  }
+
   private String defaultMapping = null;
 
   public String getDefaultMapping()
@@ -302,6 +315,10 @@ public class Preferences
    */
   public LinkedList<String> getRecentFiles()
   {
+    if (recentFiles == null)
+    {
+      recentFiles = new LinkedList<String>();
+    }
     return recentFiles;
   }
 


### PR DESCRIPTION
This more or less fixes #546.

It's not the ideal solution which would be splitting the fields into two disjunct files, <del>because that is currently impossible due to a dependency deadlock (new NetBeans cannot edit old GUI, old NetBeans cannot edit Java11 code). I hope @t-oster will manage to sort that out some time, </del>but for now I propose the following workaround:

There are two files:
- settings.private.xml: all settings including local transient settings.
- settings.xml: all settings, but with local transient settings nulled out

VisiCut tries to load settings.private.xml if it exists and is newer, otherwise falls back to settings.xml. VisiCut always saves both files. The local settings.private.xml may be deleted at any time.

Ignoring that file is currently the user's responsibility.

This change is backwards-compatible. It can be cleanly reverted without breaking anything relevant. The only downside is that if this change is reverted, the user will once loose his (rather worthless) temporary settings such as window size and recent files.

I have not tested this thoroughly but I am quite sure that the worst possible bug is that the transient settings may be lost, which one almost does not notice.
Proper testing and discussion is appreciated.