### PR TITLE
trivial fix for https://github.com/t-oster/VisiCut/issues/360

### DIFF
--- a/src/main/java/de/thomas_oster/visicut/gui/MainView.java
+++ b/src/main/java/de/thomas_oster/visicut/gui/MainView.java
@@ -607,15 +607,15 @@ public class MainView extends javax.swing.JFrame
         this.laserCutterComboBox.setSelectedItem(ld);
       }
     }
-    //hide lasercutter combo box if only one lasercutter available
+    //disable (but show) lasercutter combo box if only one lasercutter available
     if (this.laserCutterComboBox.getItemCount() == 1)
     {
       this.laserCutterComboBox.setSelectedIndex(0);
-      this.laserCutterComboBox.setVisible(false);
-      this.jLabel9.setVisible(false);
+      this.laserCutterComboBox.setEnabled(false);
     }
     else
     {
+      this.laserCutterComboBox.setEnabled(true);
       this.laserCutterComboBox.setVisible(true);
       this.jLabel9.setVisible(true);
     }


### PR DESCRIPTION
Caveat: ImageComboBox does not show the icon image, when isEnabled is false.
Keeping the ComboBox enabled all time thus would have a more consistent UX.
Choose one :-)