### PR TITLE
Reduce lag when dragging objects in preview panel

### DIFF
--- a/src/main/java/de/thomas_oster/visicut/misc/Homography.java
+++ b/src/main/java/de/thomas_oster/visicut/misc/Homography.java
@@ -191,7 +191,7 @@ public class Homography {
     // choose the one that will lose the least pixels, make a proportional image based on that scale factor
     if (output == null || output.getWidth() != width || output.getHeight() != height) {
       // See NOTE above about _ARGB.
-      output = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+      output = new BufferedImage(width, height, BufferedImage.TYPE_INT_RGB);
     }
     // for every point in output image, find sample from camera image
     final int inputWidth = input.getWidth();
@@ -209,7 +209,9 @@ public class Homography {
         if (px >=0 && px < inputWidth && py>=0 && py < inputHeight) {
           output.setRGB(x,y,input.getRGB(px,py));
         } else {
-          output.setRGB(x,y,0xFFFFFF);
+          // Unset output pixels (outside of the camera view) are left black.
+          // If this becomes a problem, we could switch to _ARGB above and add the following line:
+          // output.setRGB(x,y,0xFFFFFF);
         }
         sx += invScaleFactor;
       }


### PR DESCRIPTION
Rendering the background camera image takes very long, especially on 4K monitors. This is problematic because moving objects with the mouse has annoying lag. The background image is now cached if nothing changed, speeding up rendering times from ~100ms to ~10ms during a mouse drag operation.

I'm not sure if my solution is a good idea; it also needs some testing. I have left in some printf statements for debugging for now.

Any comments or ideas for a better solution?