### PR TITLE
Add AppImage build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@
 /lib/nbproject/private/
 /lib/build/
 /target/
+
+# AppImage builds
+.appimagecraft-build*/
+*.AppImage

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -1,0 +1,34 @@
+version: 1
+
+project:
+  name: org.visicut.visicut
+  version_command: git describe --tags
+
+build:
+  null:
+
+scripts:
+  post_build:
+    - set -x
+    # TODO: check if out-of-source builds are possible
+    - pushd "$PROJECT_ROOT"
+    - make
+    - popd
+    - |2
+      mkdir -p AppDir/usr/{bin,jre}
+      wget -O- https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.6_10.tar.gz | \
+          tar xz --strip-components=1 -C AppDir/usr/jre
+      cp "$PROJECT_ROOT"/target/visicut-*-full.jar AppDir/usr/bin/visicut.jar
+    - |2
+      set -x
+      cat > "$BUILD_DIR"/AppRun.sh <<\EOF
+      #! /bin/bash
+      export APPDIR=${APPDIR:-$(readlink -f $(dirname "$0"))}
+      exec "$APPDIR"/usr/jre/bin/java -jar "$APPDIR"/usr/bin/visicut.jar
+      EOF
+      cat "$BUILD_DIR"/AppRun.sh
+      chmod +x "$BUILD_DIR"/AppRun.sh
+
+appimage:
+  linuxdeploy:
+    extra_args: -i "$PROJECT_ROOT"/build/classes/com/t_oster/visicut/gui/resources/visicut.png -d "$PROJECT_ROOT"/distribute/linux/VisiCut.desktop --custom-apprun "$BUILD_DIR"/AppRun.sh

--- a/distribute/linux/Dockerfile.build-appimage
+++ b/distribute/linux/Dockerfile.build-appimage
@@ -1,0 +1,7 @@
+FROM alpine:latest
+
+SHELL ["sh", "-x", "-c"]
+
+RUN apk add --no-cache libc6-compat gcompat openjdk11 git wget python3 shellcheck bash make maven && \
+    python3 -m ensurepip && \
+    python3 -m pip install git+https://github.com/TheAssassin/appimagecraft.git#egg=appimagecraft

--- a/distribute/linux/build-appimage-in-docker.sh
+++ b/distribute/linux/build-appimage-in-docker.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+
+set -e
+set -x
+
+# calculate path to project root relative to this file
+project_root=$(readlink -f $(dirname "$0"))/../..
+
+# change to project root directory
+cd "$project_root"
+
+# build Docker image to cache dependencies between builds
+image=visicut-appimage-build
+dockerfile=distribute/linux/Dockerfile.build-appimage
+docker build -t "$image" -f "$dockerfile" $(dirname "$dockerfile")
+
+docker run --rm -i -v "$project_root":/ws "$image" sh -x <<EOF
+cd /ws
+export APPIMAGE_EXTRACT_AND_RUN=1
+appimagecraft
+EOF


### PR DESCRIPTION
Contributes to #565.

This PR adds support for [appimagecraft](https://github.com/TheAssassin/appimagecraft). To build AppImages, download appimagecraft (you can either install it via pip or just use the AppImages from its release page), and run it in the repository root directory.

As requested, I also added a Docker-based build script.