### PR TITLE
Make order/dithering options more accessible

### DIFF
--- a/src/main/java/de/thomas_oster/visicut/gui/propertypanel/PropertyPanel.form
+++ b/src/main/java/de/thomas_oster/visicut/gui/propertypanel/PropertyPanel.form
@@ -17,12 +17,17 @@
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" attributes="0">
-              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="editableTablePanel1" pref="0" max="32767" attributes="0"/>
+                  <Component id="editableTablePanel1" pref="400" max="32767" attributes="0"/>
                   <Group type="102" attributes="0">
-                      <Component id="jLabel1" min="-2" pref="388" max="-2" attributes="0"/>
+                      <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
                       <EmptySpace max="32767" attributes="0"/>
+                      <Component id="editMappingButton" min="-2" max="-2" attributes="0"/>
                   </Group>
               </Group>
           </Group>
@@ -31,10 +36,14 @@
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace max="-2" attributes="0"/>
               <Component id="jLabel1" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel2" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="editMappingButton" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
               <EmptySpace max="-2" attributes="0"/>
-              <Component id="editableTablePanel1" pref="62" max="32767" attributes="0"/>
+              <Component id="editableTablePanel1" pref="67" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -50,6 +59,19 @@
     <Component class="de.thomas_oster.uicomponents.EditableTablePanel" name="editableTablePanel1">
       <Properties>
         <Property name="editButtonVisible" type="boolean" value="false"/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JButton" name="editMappingButton">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Edit"/>
+      </Properties>
+      <Events>
+        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="editMappingButtonActionPerformed"/>
+      </Events>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel2">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="&lt;PROPERTY_PROFILE_SETTINGS&gt;"/>
       </Properties>
     </Component>
   </SubComponents>

--- a/src/main/java/de/thomas_oster/visicut/gui/propertypanel/PropertyPanel.java
+++ b/src/main/java/de/thomas_oster/visicut/gui/propertypanel/PropertyPanel.java
@@ -21,6 +21,7 @@ package de.thomas_oster.visicut.gui.propertypanel;
 import de.thomas_oster.liblasercut.LaserProperty;
 import de.thomas_oster.uicomponents.EditableTableProvider;
 import de.thomas_oster.visicut.VisicutModel;
+import de.thomas_oster.visicut.gui.MainView;
 import de.thomas_oster.visicut.model.LaserDevice;
 import de.thomas_oster.visicut.model.LaserProfile;
 import de.thomas_oster.visicut.model.Raster3dProfile;
@@ -91,6 +92,7 @@ public class PropertyPanel extends javax.swing.JPanel implements EditableTablePr
     this.lp = m.getProfile();
     this.editableTablePanel1.setSaveButtonVisible(modified);
     this.jLabel1.setText(modified ? "<html><b>"+text+"*</b></html>" : "<html>"+text+"</html>");
+    this.jLabel2.setText(m.getProfile().settingsToString());
   }
   
   boolean modified = false;
@@ -147,11 +149,24 @@ public class PropertyPanel extends javax.swing.JPanel implements EditableTablePr
 
     jLabel1 = new javax.swing.JLabel();
     editableTablePanel1 = new de.thomas_oster.uicomponents.EditableTablePanel();
+    editMappingButton = new javax.swing.JButton();
+    jLabel2 = new javax.swing.JLabel();
 
     java.util.ResourceBundle bundle = java.util.ResourceBundle.getBundle("de.thomas_oster/visicut/gui/resources/PropertyPanel"); // NOI18N
     jLabel1.setText(bundle.getString("PROPERTY_TITLE")); // NOI18N
 
     editableTablePanel1.setEditButtonVisible(false);
+
+    editMappingButton.setText("Edit");
+    editMappingButton.addActionListener(new java.awt.event.ActionListener()
+    {
+      public void actionPerformed(java.awt.event.ActionEvent evt)
+      {
+        editMappingButtonActionPerformed(evt);
+      }
+    });
+
+    jLabel2.setText("<PROPERTY_PROFILE_SETTINGS>");
 
     javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
     this.setLayout(layout);
@@ -160,23 +175,43 @@ public class PropertyPanel extends javax.swing.JPanel implements EditableTablePr
       .addGroup(layout.createSequentialGroup()
         .addContainerGap()
         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-          .addComponent(editableTablePanel1, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE)
+          .addComponent(editableTablePanel1, javax.swing.GroupLayout.DEFAULT_SIZE, 400, Short.MAX_VALUE)
           .addGroup(layout.createSequentialGroup()
-            .addComponent(jLabel1, javax.swing.GroupLayout.PREFERRED_SIZE, 388, javax.swing.GroupLayout.PREFERRED_SIZE)
-            .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
+            .addComponent(jLabel1)
+            .addGap(0, 0, Short.MAX_VALUE))
+          .addGroup(layout.createSequentialGroup()
+            .addComponent(jLabel2)
+            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+            .addComponent(editMappingButton))))
     );
     layout.setVerticalGroup(
       layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
       .addGroup(layout.createSequentialGroup()
-        .addContainerGap()
         .addComponent(jLabel1)
         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-        .addComponent(editableTablePanel1, javax.swing.GroupLayout.DEFAULT_SIZE, 62, Short.MAX_VALUE))
+        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+          .addComponent(jLabel2)
+          .addComponent(editMappingButton))
+        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+        .addComponent(editableTablePanel1, javax.swing.GroupLayout.DEFAULT_SIZE, 67, Short.MAX_VALUE))
     );
   }// </editor-fold>//GEN-END:initComponents
+
+    private void editMappingButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_editMappingButtonActionPerformed
+      LaserProfile changedProfile = MainView.getInstance().editLaserProfile(lp);
+      if (changedProfile == null)
+      {
+        return;
+      }
+      lp = changedProfile;
+      // TODO save the result
+    }//GEN-LAST:event_editMappingButtonActionPerformed
+
   // Variables declaration - do not modify//GEN-BEGIN:variables
+  private javax.swing.JButton editMappingButton;
   private de.thomas_oster.uicomponents.EditableTablePanel editableTablePanel1;
   private javax.swing.JLabel jLabel1;
+  private javax.swing.JLabel jLabel2;
   // End of variables declaration//GEN-END:variables
 
   public Object getNewInstance()

--- a/src/main/java/de/thomas_oster/visicut/model/LaserProfile.java
+++ b/src/main/java/de/thomas_oster/visicut/model/LaserProfile.java
@@ -129,6 +129,12 @@ public abstract class LaserProfile implements ImageListable, Cloneable
     this.name = name;
   }
 
+  /**
+   * Get human-readable summary of the settings,
+   * e.g. "500 dpi, Floyd-Steinberg dithering".
+   */
+  public abstract String settingsToString();
+
   //this attribute is unused and only kept for compatibility
   //with old XML files
   private transient boolean temporaryCopy;

--- a/src/main/java/de/thomas_oster/visicut/model/Raster3dProfile.java
+++ b/src/main/java/de/thomas_oster/visicut/model/Raster3dProfile.java
@@ -265,4 +265,11 @@ public class Raster3dProfile extends LaserProfile
     }
     return super.equalsBase(other);
   }
+
+  @Override
+  public String settingsToString()
+  {
+    // TODO I18N
+    return "" + getDPI() + " DPI, Brightness " + getColorShift() + (isInvertColors() ? ", Invert Colors" : "");
+  }
 }

--- a/src/main/java/de/thomas_oster/visicut/model/RasterProfile.java
+++ b/src/main/java/de/thomas_oster/visicut/model/RasterProfile.java
@@ -299,4 +299,11 @@ public class RasterProfile extends LaserProfile
     }
     return super.equalsBase(other);
   }
+
+  @Override
+  public String settingsToString()
+  {
+    // TODO I18N
+    return "" + getDPI() + " DPI, " + getDitherAlgorithm().toString() + ", Brightness " + getColorShift() + (isInvertColors() ? ", Invert Colors" : "");
+  }
 }

--- a/src/main/java/de/thomas_oster/visicut/model/VectorProfile.java
+++ b/src/main/java/de/thomas_oster/visicut/model/VectorProfile.java
@@ -34,6 +34,7 @@ import de.thomas_oster.visicut.model.graphicelements.lssupport.LaserScriptShape;
 import de.thomas_oster.visicut.model.graphicelements.lssupport.ScriptInterfaceLogUi;
 import de.thomas_oster.liblasercut.laserscript.ScriptInterpreter;
 import de.thomas_oster.liblasercut.laserscript.VectorPartScriptInterface;
+import de.thomas_oster.visicut.gui.EditVectorProfileDialog;
 import de.thomas_oster.visicut.managers.PreferencesManager;
 import java.awt.BasicStroke;
 import java.awt.Graphics2D;
@@ -46,6 +47,7 @@ import java.awt.geom.PathIterator;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.List;
+import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.script.ScriptException;
@@ -367,5 +369,12 @@ public class VectorProfile extends LaserProfile
       return false;
     }
     return super.equalsBase(obj);
+  }
+
+  @Override
+  public String settingsToString()
+  {
+    org.jdesktop.application.ResourceMap resourceMap = org.jdesktop.application.Application.getInstance(de.thomas_oster.visicut.gui.VisicutApp.class).getContext().getResourceMap(EditVectorProfileDialog.class);
+    return (isUseOutline() ? resourceMap.getString("useOutline") + ", " : "") + resourceMap.getString("Optimization") + ": " + getOrderStrategy().toString();
   }
 }


### PR DESCRIPTION
I'd like to make the dithering and vector sorting options more discoverable by showing them besides the speed/power settings. Currently I am stuck with how to make editing work -- I can show an edit dialog but it seems impossible to apply the modified profile, at least without major changes to the code structure.

![screenshot](https://user-images.githubusercontent.com/1520891/76153188-e9c5c700-60c8-11ea-98ea-27c2b9479910.png)