### PR TITLE
Fixes #374: Duplicate element then non-drag reposition gets confused

### DIFF
--- a/src/main/java/de/thomas_oster/visicut/VisicutModel.java
+++ b/src/main/java/de/thomas_oster/visicut/VisicutModel.java
@@ -160,6 +160,7 @@ public class VisicutModel
     }
     this.plfFile.add(dup);
     this.propertyChangeSupport.firePropertyChange(PROP_PLF_PART_ADDED, null, dup);
+    this.setSelectedPart(dup);
   }
 
   public Point2D.Double getStartPoint()

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/GraphicSet.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/GraphicSet.java
@@ -301,7 +301,7 @@ public class GraphicSet extends LinkedList<GraphicObject>
   {
     GraphicSet result = new GraphicSet();
     result.addAll(this);
-    result.setTransform(this.getTransform());
+    result.setTransform(new AffineTransform(this.getTransform()));
     result.boundingBoxCache = boundingBoxCache;
     result.originalBoundingBoxCache = originalBoundingBoxCache;
     result.basicTransform = basicTransform;


### PR DESCRIPTION

Fixes #374 .

Holding on to the same transform reference as the GraphicSet being cloned is what caused the observed wonky behaviour.

I'm piggybacking a second commit to select the duplicated part because I feel it makes sense to match the behaviour of the 'add part' functionality.