### PR TITLE
Make importers aware of bottom left coordinate system

### DIFF
--- a/src/main/java/de/thomas_oster/visicut/VisicutModel.java
+++ b/src/main/java/de/thomas_oster/visicut/VisicutModel.java
@@ -699,7 +699,7 @@ public class VisicutModel extends Component // FIXME: "extends Component" isn't 
 
   public PlfPart loadGraphicFile(File f, List<String> warnings) throws ImportException
   {
-    return this.getGraphicFileImporter().importFile(f, warnings);
+    return this.getGraphicFileImporter().importFile(f, getSelectedLaserDevice().isOriginBottomLeft(), getSelectedLaserDevice().getLaserCutter().getBedHeight(), warnings);
   }
 
 

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/AbstractImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/AbstractImporter.java
@@ -30,14 +30,14 @@ import java.util.List;
 public abstract class AbstractImporter implements Importer
 {
 
-  public PlfPart importFile(File inputFile, List<String> warnings) throws ImportException
+  public PlfPart importFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     PlfPart p = new PlfPart();
     p.setSourceFile(inputFile);
-    p.setGraphicObjects(this.importSetFromFile(inputFile, warnings));
+    p.setGraphicObjects(this.importSetFromFile(inputFile, originIsBottomLeft, bedHeightInMm, warnings));
     return p;
   }
   
-  public abstract GraphicSet importSetFromFile(File inputFile, List<String> warnings) throws ImportException;
+  public abstract GraphicSet importSetFromFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException;
 
 }

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/GraphicFileImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/GraphicFileImporter.java
@@ -69,7 +69,7 @@ public class GraphicFileImporter implements Importer
     }
   }
 
-  public PlfPart importFile(File inputFile, List<String> warnings) throws ImportException
+  public PlfPart importFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     if (inputFile == null)
     {
@@ -85,7 +85,7 @@ public class GraphicFileImporter implements Importer
       {
         if (i.getFileFilter().accept(inputFile))
         {
-          PlfPart gs = i.importFile(inputFile, warnings);
+          PlfPart gs = i.importFile(inputFile, originIsBottomLeft, bedHeightInMm, warnings);
           return gs;
         }
       }

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/Importer.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/Importer.java
@@ -38,6 +38,6 @@ public interface Importer
    * They will be displayed to the user, but no
    * further action is taken
    */
-  PlfPart importFile(File inputFile, List<String> warnings) throws ImportException;
+  PlfPart importFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException;
   
 }

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/dxfsupport/DXFImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/dxfsupport/DXFImporter.java
@@ -51,7 +51,7 @@ import org.xml.sax.SAXException;
 public class DXFImporter extends AbstractImporter
 {
 
-  public GraphicSet importSetFromFile(File inputFile, List<String> warnings) throws ImportException
+  public GraphicSet importSetFromFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     GraphicSet result = new GraphicSet();
     try
@@ -92,7 +92,7 @@ public class DXFImporter extends AbstractImporter
         }).start();
       SVGImporter svgimp = new SVGImporter();
       //TODO Check which resolution it exports and adapt it to mm
-      result = svgimp.importSetFromFile(in, inputFile.getName(), 1/Util.mm2inch(1), warnings);
+      result = svgimp.importSetFromFile(in, inputFile.getName(), 1/Util.mm2inch(1), originIsBottomLeft, bedHeightInMm, warnings);
     }
     catch (Exception ex)
     {

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/epssupport/EPSImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/epssupport/EPSImporter.java
@@ -96,7 +96,7 @@ public class EPSImporter extends AbstractImporter
     return result;
   }
 
-  public GraphicSet importSetFromFile(File inputFile, List<String> warnings) throws ImportException
+  public GraphicSet importSetFromFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     Writer out = null;
     try
@@ -123,7 +123,7 @@ public class EPSImporter extends AbstractImporter
       File tmp = File.createTempFile("temp", "svg");
       tmp.deleteOnExit();
       svgGenerator.stream(new FileWriter(tmp));
-      GraphicSet result = new SVGImporter().importSetFromFile(tmp, warnings);
+      GraphicSet result = new SVGImporter().importSetFromFile(tmp, originIsBottomLeft, bedHeightInMm, warnings);
       //Assume the EPS has been created with 72DPI (from Inkscape)
       double px2mm = Util.inch2mm(1d/72d);
       result.setBasicTransform(AffineTransform.getScaleInstance(px2mm, px2mm));

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/gcodesupport/GCodeImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/gcodesupport/GCodeImporter.java
@@ -94,10 +94,11 @@ public class GCodeImporter extends AbstractImporter
   }
   
   @Override
-  public GraphicSet importSetFromFile(File inputFile, List<String> warnings) throws ImportException
+  public GraphicSet importSetFromFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     try
     {
+      //TODO if originIsBottomLeft replace y with bedHeight-y everywhere (?)
       BufferedReader reader = new BufferedReader(new FileReader(inputFile));
       GraphicSet result = new GraphicSet();
       GeneralPath resultingShape = new GeneralPath();

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/jpgpngsupport/JPGPNGImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/jpgpngsupport/JPGPNGImporter.java
@@ -37,7 +37,7 @@ import javax.swing.filechooser.FileFilter;
 public class JPGPNGImporter extends AbstractImporter
 {
 
-  public GraphicSet importSetFromFile(File inputFile, List<String> warnings) throws ImportException
+  public GraphicSet importSetFromFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     try
     {

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/lssupport/LaserScriptImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/lssupport/LaserScriptImporter.java
@@ -64,7 +64,7 @@ public class LaserScriptImporter extends AbstractImporter
     };
   }
 
-  public GraphicSet importSetFromFile(File inputFile, List<String> warnings) throws ImportException
+  public GraphicSet importSetFromFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     GraphicSet result = new GraphicSet();
     result.setBasicTransform(new AffineTransform());

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/psvgsupport/PSVGImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/psvgsupport/PSVGImporter.java
@@ -186,11 +186,11 @@ public class PSVGImporter extends ParametricSVGImporter
   }
 
   @Override
-  public ParametricPlfPart importFile(File inputFile, List<String> warnings) throws ImportException
+  public ParametricPlfPart importFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     try
     {
-      return super.importFile(translateToParametricSvg(inputFile), warnings);
+      return super.importFile(translateToParametricSvg(inputFile), originIsBottomLeft, bedHeightInMm, warnings);
     }
     catch (Exception ex)
     {

--- a/src/main/java/de/thomas_oster/visicut/model/graphicelements/psvgsupport/ParametricSVGImporter.java
+++ b/src/main/java/de/thomas_oster/visicut/model/graphicelements/psvgsupport/ParametricSVGImporter.java
@@ -60,6 +60,9 @@ public class ParametricSVGImporter implements Importer
 
   private static FileFilter FILTER = new ExtensionFilter(".parametric.svg", "Parametric SVG files");
   
+  private boolean originIsBottomLeft = false;
+  private double bedHeightInMm = 0; 
+  
   public Map<String, Parameter> parseParameters(File inputFile, List<String> warnings) throws ParserConfigurationException, SAXException, IOException
   {
     
@@ -178,10 +181,12 @@ public class ParametricSVGImporter implements Importer
     return FILTER;
   }
   
-  public ParametricPlfPart importFile(File inputFile, List<String> warnings) throws ImportException
+  public ParametricPlfPart importFile(File inputFile, boolean originIsBottomLeft, double bedHeightInMm, List<String> warnings) throws ImportException
   {
     try
     {
+      this.originIsBottomLeft = originIsBottomLeft;
+      this.bedHeightInMm = bedHeightInMm;
       Map<String, Parameter> parameters =  this.parseParameters(inputFile, warnings);
       if (new File(inputFile.getAbsolutePath()+".parameters").exists())
       {
@@ -246,7 +251,6 @@ public class ParametricSVGImporter implements Importer
   {
     try
     {
-      
       SVGImporter svg = new SVGImporter();
       double resolution = svg.determineResolution(inputFile, warnings);
       final PipedOutputStream out = new PipedOutputStream();
@@ -269,7 +273,7 @@ public class ParametricSVGImporter implements Importer
           }
         }
       }.start();    
-      return (new SVGImporter()).importSetFromFile(in, inputFile.getName(), resolution, warnings);
+      return (new SVGImporter()).importSetFromFile(in, inputFile.getName(), resolution, originIsBottomLeft, bedHeightInMm, warnings);
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
In #633 @LaFabrique35 suggests, that if the lasercutter has a bottom-left coordinate system, the files should be placed relative to the bottom left.
E.g. if you have this SVG:

[example.zip](https://github.com/t-oster/VisiCut/files/7900304/example.zip)

the rectangle is positioned x=20 and y=30 (relative to the bottom of the view box).

I started implementing this, but I have a few things to consider:

1. Is this what all users would expect? The SVG file itself has the coordinate system always top left as dictated by the SVG standard, but the position where the SVG viewbox is placed on the laserbed is changed.
2. What about the G-Code importer? Should we interpret all Y-Coordinates in the G-Code as relative to bottom left (is anyone using the G-Code importer anyway?)
3. Should the Raster-Importers (JPG,PNG etc) import the drawing also bottom-left?

Binaries are at https://download.visicut.org/feature-633-import-bottom-left
