### PR TITLE
Fix AppImage build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 # AppImage builds
 .appimagecraft-build*/
 *.AppImage
+squashfs-root/

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -31,4 +31,4 @@ scripts:
 
 appimage:
   linuxdeploy:
-    extra_args: -i "$PROJECT_ROOT"/build/classes/com/t_oster/visicut/gui/resources/visicut.png -d "$PROJECT_ROOT"/distribute/linux/VisiCut.desktop --custom-apprun "$BUILD_DIR"/AppRun.sh
+    extra_args: -i "$PROJECT_ROOT"/src/main/resources/de/thomas_oster/visicut/gui/resources/visicut.png -d "$PROJECT_ROOT"/distribute/linux/VisiCut.desktop --custom-apprun "$BUILD_DIR"/AppRun.sh

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -16,7 +16,7 @@ scripts:
     - popd
     - |2
       mkdir -p AppDir/usr/{bin,jre}
-      wget -O- https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_linux_hotspot_11.0.6_10.tar.gz | \
+      wget -O- https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16.0.1%2B9_openj9-0.26.0/OpenJDK16U-jre_x64_linux_openj9_16.0.1_9_openj9-0.26.0.tar.gz | \
           tar xz --strip-components=1 -C AppDir/usr/jre
       cp "$PROJECT_ROOT"/target/visicut-*-full.jar AppDir/usr/bin/visicut.jar
     - |2

--- a/appimagecraft.yml
+++ b/appimagecraft.yml
@@ -23,7 +23,7 @@ scripts:
       set -x
       cat > "$BUILD_DIR"/AppRun.sh <<\EOF
       #! /bin/bash
-      export APPDIR=${APPDIR:-$(readlink -f $(dirname "$0"))}
+      export APPDIR="${APPDIR:-"$(readlink -f "$(dirname "$0")")"}"
       exec "$APPDIR"/usr/jre/bin/java -jar "$APPDIR"/usr/bin/visicut.jar
       EOF
       cat "$BUILD_DIR"/AppRun.sh

--- a/distribute/linux/Dockerfile.build-appimage
+++ b/distribute/linux/Dockerfile.build-appimage
@@ -2,6 +2,6 @@ FROM alpine:latest
 
 SHELL ["sh", "-x", "-c"]
 
-RUN apk add --no-cache libc6-compat gcompat openjdk11 git wget python3 shellcheck bash make maven && \
+RUN apk add --no-cache libc6-compat gcompat openjdk16 git wget python3 shellcheck bash make maven && \
     python3 -m ensurepip && \
     python3 -m pip install git+https://github.com/TheAssassin/appimagecraft.git#egg=appimagecraft

--- a/distribute/linux/build-appimage-in-docker.sh
+++ b/distribute/linux/build-appimage-in-docker.sh
@@ -17,5 +17,6 @@ docker build -t "$image" -f "$dockerfile" $(dirname "$dockerfile")
 docker run --rm -i -v "$project_root":/ws "$image" sh -x <<EOF
 cd /ws
 export APPIMAGE_EXTRACT_AND_RUN=1
+git config --global --add safe.directory /ws
 appimagecraft
 EOF


### PR DESCRIPTION
The appimagecraft config is outdated and doesn't work any more. This PR fixes the problems. It also takes the chance to update to a newer JRE.