### PR TITLE
build with GH actions and Docker

### DIFF
--- a/.github/workflows/external-buildserver.yml
+++ b/.github/workflows/external-buildserver.yml
@@ -1,5 +1,5 @@
 name: Trigger Buildserver
-run-name: ${{ github.actor }} triggers buildserver
+run-name: ${{ github.actor }} triggers the external buildserver to update download.visicut.org
 on:
   push:
     branches:

--- a/.github/workflows/github-build.yml
+++ b/.github/workflows/github-build.yml
@@ -1,0 +1,24 @@
+name: Build
+run-name: ${{ github.actor }} builds using docker. The output is currently ignored
+on:
+  push:
+    branches_ignore:
+     - gh-pages
+  pull_request:
+    branches_ignore:
+     - gh-pages
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    container: 'docker://registry.gitlab.com/t-oster/visicutbuildservice'
+    steps:
+      - name: Setup directories
+        run: mkdir -p /app/build /app/output
+      - name: Run build
+        run: /app/build.sh
+      - name: Archive built files
+        uses: actions/upload-artifact@v3
+        with:
+          name: output binaries
+          path: |
+            /app/output/**


### PR DESCRIPTION
(updated)

Add GitHub actions in parallel to the old buildserver.

Currently implemented:
- Trigger the old buildserver (unchanged) for every commit on master
- Run build pipeline on GH actions for every commit and PR
- Save output as build artifact (Note: artifacts are deleted after 90 days)

Not implemented:
- Permanent archive / release creation