### PR TITLE
Don't assume hard-coded bash location. Replace `which` with `command`.

### DIFF
--- a/distribute/distribute-docker.sh
+++ b/distribute/distribute-docker.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -euxo pipefail
 

--- a/distribute/distribute.sh
+++ b/distribute/distribute.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/distribute/linux/build-appimage-in-docker.sh
+++ b/distribute/linux/build-appimage-in-docker.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -x

--- a/generateChangelog.sh
+++ b/generateChangelog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [ "$1" == '--until' ]
 then
 	UNTIL=$2

--- a/generatesplash.sh
+++ b/generatesplash.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Checking for rsvg..."
-if which rsvg-convert >/dev/null 2>&1
+if command -v rsvg-convert >/dev/null 2>&1
 then
 	echo "found rsvg-convert."
 else

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Performs some sanity and code cleanness tests. Intended to be run before every commit
 
 echo "Checking for copryight header"

--- a/tools/cameraserver/capture.sh
+++ b/tools/cameraserver/capture.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of VisiCut.
 # Copyright (C) 2011 Thomas Oster <thomas.oster@rwth-aachen.de>

--- a/tools/cameraserver/config.sh
+++ b/tools/cameraserver/config.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Rotation of the image before sending
 ROTATION=0
 # Snapshot tool can either be gphoto2 or snap
 TOOL=snap
 
 SNAPBIN=/Users/fm/Desktop/VisiCutMaterialDb/snap
-GPHOTO2BIN=$(which gphoto2)
+GPHOTO2BIN=$(command -v gphoto2)

--- a/tools/cameraserver/server.sh
+++ b/tools/cameraserver/server.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # This file is part of VisiCut.
 # Copyright (C) 2011 Thomas Oster <thomas.oster@rwth-aachen.de>
@@ -65,10 +65,10 @@ trap 'shutdown' SIGTERM SIGINT
 while :
 do 
 	echo "Waiting for Connection..."
-	if [ -x "$(which netcat)" ]
+	if [ -x "$(command -v netcat)" ]
 	then
 		netcat -l -p $PORT < fifo | ./capture.sh > fifo
-	elif [ -x "$(which nc)" ]
+	elif [ -x "$(command -v nc)" ]
 	then
 		nc -l $PORT < fifo | ./capture.sh > fifo
 	else

--- a/tools/inkscape_extension/install.sh
+++ b/tools/inkscape_extension/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "This will install the inkscape-extension for VisiCut"
 echo "Do you want to continue? (y/n)"
 read answ

--- a/tools/settings-maintenance/get-used-classes.sh
+++ b/tools/settings-maintenance/get-used-classes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 set -o pipefail
 


### PR DESCRIPTION
Two little changes to make shell scripts work more universally.

Not all Unixes have bash installed in /bin/bash; use the /usr/bin/env bash pattern to make finding it more platform independent.

The `which` command is deprecated in some Linux distributions (e.g. Debian); replacing it with more canonical command -v.