### PR TITLE
Fix location of embedded JRE in macOS bundle

### DIFF
--- a/distribute/distribute.sh
+++ b/distribute/distribute.sh
@@ -228,7 +228,7 @@ EOF
 
             # deploy jre
             mkdir -p VisiCut.app/Contents/Plugins/
-            mv jre/* VisiCut.app/Contents/Plugins/
+            mv jre/ VisiCut.app/Contents/Plugins/JRE/
 
             # create bundle
             zip -r bundle.zip VisiCut.app/


### PR DESCRIPTION
This was inadvertently broken in 4bd60b0. The JRE is intended to be installed under Contents/Plugins/JRE, but the refactoring inadvertently made it be installed under Contents/Plugins only. In turn, this meant the launched script could no longer find the JRE and gave an error instead of starting the application.

Fixes #684.