### PR TITLE
Suggest to preserve the user entered text  in the JobName TextField

### DIFF
--- a/src/main/java/de/thomas_oster/visicut/gui/MainView.java
+++ b/src/main/java/de/thomas_oster/visicut/gui/MainView.java
@@ -1986,7 +1986,6 @@ public class MainView extends javax.swing.JFrame
         execute = false;
       }
     }
-    this.jTextFieldJobName.setText("");
     this.exportGcodeMenuItem.setEnabled(execute);
     this.calculateTimeButton.setEnabled(execute);
     this.executeJobButton.setEnabled(execute);
@@ -2113,6 +2112,10 @@ private void aboutMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN
   private String generateJobName() {
     jobnumber++;
     String nameprefix = jTextFieldJobName.getText();
+    if (nameprefix.length() > 0)
+    {
+      nameprefix = nameprefix + " ";	// insert a whitespace after prefix to make it look nicer.
+    } 
     //
     // Most simplistic implementation of user editable job names:
     //  - we just add a prefix, if any. (This is okay for Zing lasers that only display 16 chars.)
@@ -3653,7 +3656,7 @@ private void projectorActiveMenuItemActionPerformed(java.awt.event.ActionEvent e
       executeJobButton.setEnabled(!disable);
       executeJobMenuItem.setEnabled(!disable);
       calculateTimeButton.setEnabled(!disable);
-      jTextFieldJobName.setText("");
+      // jTextFieldJobName.setText("");
 
       // Message is automatically removed and closed, therefore no close button
       Message m = new Message("Info", bundle.getString("QR_CODE_DETECTION_GUI_DISABLE_TEXT"), Message.Type.INFO, new de.thomas_oster.uicomponents.warnings.Action[]

--- a/src/main/java/de/thomas_oster/visicut/gui/MainView.java
+++ b/src/main/java/de/thomas_oster/visicut/gui/MainView.java
@@ -2115,12 +2115,12 @@ private void aboutMenuItemActionPerformed(java.awt.event.ActionEvent evt) {//GEN
     if (nameprefix.length() > 0)
     {
       nameprefix = nameprefix + " ";	// insert a whitespace after prefix to make it look nicer.
-    } 
+    }
     //
     // Most simplistic implementation of user editable job names:
     //  - we just add a prefix, if any. (This is okay for Zing lasers that only display 16 chars.)
-    // Todo: Better compute the next proposed job name in e.g. refreshExecuteButtons() ahead of time 
-    // and show it in jTextFieldJobName near the Execute button. When we come here, just retrieve the 
+    // Todo: Better compute the next proposed job name in e.g. refreshExecuteButtons() ahead of time
+    // and show it in jTextFieldJobName near the Execute button. When we come here, just retrieve the
     // (possibly edited) name from there.
     //
     String prefix = visicutModel1.getSelectedLaserDevice().getJobPrefix();


### PR DESCRIPTION
Currently visicut deletes the value, when a) the laser is changed, b) material is changed, or c) the mapping is changed.
This makes it tedious, if I want to e.g. laser the same file different mappings, which I frequently do. I'd prefer to just edit the prefix, instead of entering it again in full each time.
Preserving the text is also nicer in the case an inexperienced user wants to enter the job name before choosing a mapping.

Also, I suggest to insert a whitespace after the prefix to make it look nicer.