### PR TITLE
Release with GitHub actions

### DIFF
--- a/.github/workflows/github-build.yml
+++ b/.github/workflows/github-build.yml
@@ -1,5 +1,5 @@
 name: Build
-run-name: ${{ github.actor }} builds using docker. The output is currently ignored
+
 on:
   push:
     branches_ignore:
@@ -7,10 +7,12 @@ on:
   pull_request:
     branches_ignore:
      - gh-pages
+  workflow_dispatch:
+
 jobs:
-  Build:
+  build:
     runs-on: ubuntu-latest
-    container: 'docker://registry.gitlab.com/t-oster/visicutbuildservice'
+    container: 'registry.gitlab.com/t-oster/visicutbuildservice'
     steps:
       - name: Setup directories
         run: mkdir -p /app/build /app/output
@@ -22,3 +24,58 @@ jobs:
           name: output binaries
           path: |
             /app/output/**
+
+  distribute:
+    strategy:
+      fail-fast: false
+
+      matrix:
+        target:
+          - zip
+          - windows-nsis
+          - macos-bundle
+          - linux-appimage
+          - linux-checkinstall
+
+    name: Distribute ${{ matrix.target }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
+
+      - name: Build distribution
+        run: |
+          # we use a separate directory called output to "collect" all the build artifacts
+          # this makes uploading the artifacts a *lot* easier
+          mkdir output
+          pushd output
+          bash ../distribute/distribute-docker.sh ${{ matrix.target }}
+
+      - name: Archive built files
+        uses: actions/upload-artifact@v3
+        with:
+          name: output binaries
+          path: |
+            output/*
+
+  upload:
+    name: Create release and upload artifacts
+    needs:
+      - distribute
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+      - name: Inspect directory after downloading artifacts
+        run: ls -alFR
+      - name: Create release and upload artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+            url="$(curl -s https://api.github.com/repos/TheAssassin/pyuploadtool/releases/latest | grep browser_download_url | grep AppImage | cut -d'"' -f4)"
+            wget "$url"
+            chmod +x pyuploadtool-x86_64.AppImage
+            ./pyuploadtool-x86_64.AppImage "output binaries"/*.*

--- a/.github/workflows/github-build.yml
+++ b/.github/workflows/github-build.yml
@@ -60,7 +60,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-            url="$(curl -s https://api.github.com/repos/TheAssassin/pyuploadtool/releases/latest | grep browser_download_url | grep AppImage | cut -d'"' -f4)"
-            wget "$url"
+            wget https://github.com/TheAssassin/pyuploadtool/releases/download/20231223-1/pyuploadtool-x86_64.AppImage
             chmod +x pyuploadtool-x86_64.AppImage
             ./pyuploadtool-x86_64.AppImage "output binaries"/*.*

--- a/.github/workflows/github-build.yml
+++ b/.github/workflows/github-build.yml
@@ -10,21 +10,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    container: 'registry.gitlab.com/t-oster/visicutbuildservice'
-    steps:
-      - name: Setup directories
-        run: mkdir -p /app/build /app/output
-      - name: Run build
-        run: /app/build.sh
-      - name: Archive built files
-        uses: actions/upload-artifact@v3
-        with:
-          name: output binaries
-          path: |
-            /app/output/**
-
   distribute:
     strategy:
       fail-fast: false

--- a/distribute/Dockerfile
+++ b/distribute/Dockerfile
@@ -13,7 +13,7 @@ ENV LANG C.UTF-8
 RUN apt-get update && \
     apt-get install -y openjdk-11-jdk git wget shellcheck bash make maven python3-minimal python3-pip \
         nsis zip libfuse2 checkinstall makepkg fonts-noto-extra potrace sudo && \
-    python3 -m pip install git+https://github.com/TheAssassin/appimagecraft.git#egg=appimagecraft
+    python3 -m pip install git+https://github.com/TheAssassin/appimagecraft.git@6b36fda#egg=appimagecraft
 
 # we don't have a defined $HOME, but we need Maven to write the libLaserCut artifact somewhere
 COPY docker/maven-settings.xml /usr/share/maven/conf/settings.xml

--- a/distribute/Dockerfile
+++ b/distribute/Dockerfile
@@ -12,7 +12,7 @@ ENV LANG C.UTF-8
 # note: don't build with OpenJDK > 16, as this is the runtime we ship
 RUN apt-get update && \
     apt-get install -y openjdk-11-jdk git wget shellcheck bash make maven python3-minimal python3-pip \
-        nsis zip libfuse2 checkinstall makepkg && \
+        nsis zip libfuse2 checkinstall makepkg fonts-noto-extra potrace sudo && \
     python3 -m pip install git+https://github.com/TheAssassin/appimagecraft.git#egg=appimagecraft
 
 # we don't have a defined $HOME, but we need Maven to write the libLaserCut artifact somewhere

--- a/distribute/Dockerfile
+++ b/distribute/Dockerfile
@@ -6,6 +6,9 @@ SHELL ["bash", "-x", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+# workaround nsis bug: https://sourceforge.net/p/nsis/bugs/1180/
+ENV LANG C.UTF-8
+
 # note: don't build with OpenJDK > 16, as this is the runtime we ship
 RUN apt-get update && \
     apt-get install -y openjdk-11-jdk git wget shellcheck bash make maven python3-minimal python3-pip \

--- a/distribute/Dockerfile
+++ b/distribute/Dockerfile
@@ -12,10 +12,11 @@ RUN apt-get update && \
         nsis zip libfuse2 checkinstall makepkg && \
     python3 -m pip install git+https://github.com/TheAssassin/appimagecraft.git#egg=appimagecraft
 
-# create fake home directory so that maven can create a ~/.m2 directory
-RUN mkdir /fakehome && \
-    chmod 777 /fakehome
-ENV HOME=/fakehome
+# we don't have a defined $HOME, but we need Maven to write the libLaserCut artifact somewhere
+COPY docker/maven-settings.xml /usr/share/maven/conf/settings.xml
 
 # we shouldn't expect FUSE to work within Docker
 ENV APPIMAGE_EXTRACT_AND_RUN=1
+
+VOLUME /visicut
+RUN git config --global --add safe.directory /visicut

--- a/distribute/distribute-docker.sh
+++ b/distribute/distribute-docker.sh
@@ -5,14 +5,14 @@ set -euxo pipefail
 # make it easier to work from the script
 distribute_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 
+image_name="visicut-distribution"
+
+docker build -t "$image_name" -f "$distribute_dir"/Dockerfile "$distribute_dir"
+
 extra_args=()
 if [[ -t 0 ]]; then
     extra_args+=("-t")
 fi
-
-# we use VisicutBuilder to ensure compatibility with it
-# for instance, it provides a specific NSIS version which is the only one the project can be built with
-image_name="registry.gitlab.com/t-oster/visicutbuildservice"
 
 # mount current working directory as /cwd so that the resulting artifacts show up in it
 # also mount distribute/'s parent directory so that distribute.sh has access to all the necessary files
@@ -29,6 +29,5 @@ docker run \
     -v "$distribute_dir/..":/visicut \
     --user "$(id -u)" \
     --tmpfs "/ramdisk:uid=$(id -u),gid=$(id -g),exec" \
-    --entrypoint bash \
     "$image_name" \
     /visicut/distribute/distribute.sh "$@"

--- a/distribute/distribute-docker.sh
+++ b/distribute/distribute-docker.sh
@@ -9,15 +9,21 @@ image_name="visicut-distribution"
 
 docker build -t "$image_name" -f "$distribute_dir"/Dockerfile "$distribute_dir"
 
+extra_args=()
+if [[ -t 0 ]]; then
+    extra_args+=("-t")
+fi
+
 # mount current working directory as /cwd so that the resulting artifacts show up in it
 # also mount distribute/'s parent directory so that distribute.sh has access to all the necessary files
 # the reason is that we cannot predict where this script is called from but want to avoid any difference in executing
 # this script instead of distribute.sh directly
 docker run \
+    "${extra_args[@]}" \
     --rm \
     -e BUILD \
     -e TMPDIR=/ramdisk \
-    -it \
+    -i \
     -w /cwd \
     -v "$PWD":/cwd \
     -v "$distribute_dir/..":/visicut \

--- a/distribute/distribute-docker.sh
+++ b/distribute/distribute-docker.sh
@@ -5,14 +5,14 @@ set -euxo pipefail
 # make it easier to work from the script
 distribute_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
 
-image_name="visicut-distribution"
-
-docker build -t "$image_name" -f "$distribute_dir"/Dockerfile "$distribute_dir"
-
 extra_args=()
 if [[ -t 0 ]]; then
     extra_args+=("-t")
 fi
+
+# we use VisicutBuilder to ensure compatibility with it
+# for instance, it provides a specific NSIS version which is the only one the project can be built with
+image_name="registry.gitlab.com/t-oster/visicutbuildservice"
 
 # mount current working directory as /cwd so that the resulting artifacts show up in it
 # also mount distribute/'s parent directory so that distribute.sh has access to all the necessary files
@@ -29,5 +29,6 @@ docker run \
     -v "$distribute_dir/..":/visicut \
     --user "$(id -u)" \
     --tmpfs "/ramdisk:uid=$(id -u),gid=$(id -g),exec" \
+    --entrypoint bash \
     "$image_name" \
     /visicut/distribute/distribute.sh "$@"

--- a/distribute/distribute.sh
+++ b/distribute/distribute.sh
@@ -69,9 +69,9 @@ export VERSION
 if [ "${NO_BUILD:-}" == "" ]; then
     log "Building VisiCut JAR"
     # TODO: make out-of-source builds possible
-	pushd "$project_root_dir"
-	make clean jar
-	popd
+    pushd "$project_root_dir"
+    make clean jar
+    popd
 fi
 
 # we "ab"use the deployment directory to create the "visicut directory"
@@ -143,7 +143,8 @@ for target in "$@"; do
         # need to copy the NSIS files to the build dir, since relative paths are relative to the config directory
         cp -Rv "$distribute_dir"/windows "$build_dir"/windows-launcher
         pushd windows-launcher
-        makensis launcher.nsi
+        # force charset to UTF8, otherwise the combined license file will cause conversion errors ("unable to convert to codepage 0")
+        makensis -INPUTCHARSET UTF8 launcher.nsi
         popd
         mv -v windows-launcher/VisiCut.exe visicut/
         rm -rf windows-launcher/

--- a/distribute/docker/maven-settings.xml
+++ b/distribute/docker/maven-settings.xml
@@ -1,0 +1,4 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <localRepository>/tmp/.m2/repository</localRepository>
+</settings>

--- a/distribute/windows/installer.nsi
+++ b/distribute/windows/installer.nsi
@@ -33,7 +33,7 @@
 ;Pages
  
   ; License page
-;  !insertmacro MUI_PAGE_LICENSE "license-with-jre.txt"
+  !insertmacro MUI_PAGE_LICENSE "license-with-jre.txt"
   !insertmacro MUI_PAGE_INSTFILES
   !define MUI_INSTFILESPAGE_FINISHHEADER_TEXT "Installation complete"
   !define MUI_PAGE_HEADER_TEXT "Installing"

--- a/distribute/windows/installer.nsi
+++ b/distribute/windows/installer.nsi
@@ -33,7 +33,7 @@
 ;Pages
  
   ; License page
-  !insertmacro MUI_PAGE_LICENSE "license-with-jre.txt"
+;  !insertmacro MUI_PAGE_LICENSE "license-with-jre.txt"
   !insertmacro MUI_PAGE_INSTFILES
   !define MUI_INSTFILESPAGE_FINISHHEADER_TEXT "Installation complete"
   !define MUI_PAGE_HEADER_TEXT "Installing"


### PR DESCRIPTION
Fixes #670.

This PR introduces a GitHub actions workflow to create releases on GitHub with all the available binaries.

It is intended to replace the external VisiCut build server and make it easier for contributors to maintain their own builds without the need for external infrastructure and complicated setup procedures.

Please note that the second commit is a workaround for an NSIS bug. The generated license file contains non-ASCII characters (it is UTF-8 encoded). I cannot make NSIS accept the file as-is, it claims it violates codepage 0 (to my understanding, this is the currently active codepage; on Windows, it should be some UTF-8 compatible scheme; I have no idea what the default on Debian is, though).

A demo of the generated release can be found here: https://github.com/TheAssassin/VisiCut/releases/tag/continuous
Tagged releases will generate a non-prerelease entry. The text can be customized, please see pyuploadtool's docs.