### PR TITLE
Fixed Mac OS environment permissions error when launching in Sequoia

### DIFF
--- a/distribute/mac/VisiCut.app/Contents/Info.plist
+++ b/distribute/mac/VisiCut.app/Contents/Info.plist
@@ -68,11 +68,6 @@
     <key>JVMRuntimePath</key>
     <string></string>
     -->
-    <key>LSEnvironment</key>
-    <dict>
-        <key>JAVA_HOME</key>
-        <string>Contents/Plugins/JRE/Contents/Home/</string>
-    </dict>
     <key>JVMMainClassName</key>
     <string>de.thomas_oster.visicut.gui.VisicutApp</string>
     <key>JVMClassPaths</key>


### PR DESCRIPTION
Fixes #738 informed by fix found over [here](https://github.com/streamlink/streamlink-twitch-gui/issues/1027#issuecomment-2449789501).